### PR TITLE
Fix/Webengine server host config

### DIFF
--- a/deploy_server.sh
+++ b/deploy_server.sh
@@ -39,7 +39,7 @@ DeployServer() {
 
 StartServer() {
     cp ${SOURCE_DIR}/${TARGET_SCRIPT} ${TARGET_DIR}
-    python3 ${TARGET_DIR}/${TARGET_SCRIPT}
+    python3 ${TARGET_DIR}/${TARGET_SCRIPT} 127.0.0.1 8081
     rm ${TARGET_DIR}/${TARGET_SCRIPT}
 }
 

--- a/tools/file_server.py
+++ b/tools/file_server.py
@@ -34,7 +34,8 @@ import os
 import sys
 
 class FileServer():
-  def __init__(self, _port, _secret_key):
+  def __init__(self, _host, _port, _secret_key):
+    self.HOST = _host
     self.PORT = _port
     self.SECRET_KEY = _secret_key
     self.tcp_server = None
@@ -42,7 +43,7 @@ class FileServer():
   def start(self):
     socketserver.TCPServer.allow_reuse_address = True
     try:
-      self.tcp_server = socketserver.TCPServer(("127.0.0.1", self.PORT), self.getRequestHandler(self.SECRET_KEY))
+      self.tcp_server = socketserver.TCPServer((self.HOST, self.PORT), self.getRequestHandler(self.SECRET_KEY))
       self.tcp_server.serve_forever()
       self.stop()
     except KeyboardInterrupt:
@@ -82,8 +83,9 @@ class FileServer():
     return Handler
 
 if __name__ == '__main__':
-  port = int(sys.argv[1])
-  secret_key = str(sys.argv[2])
+  host = str(sys.argv[1])
+  port = int(sys.argv[2])
+  secret_key = str(sys.argv[3])
 
-  fs = FileServer(port, secret_key)
+  fs = FileServer(host, port, secret_key)
   fs.start()

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -321,7 +321,7 @@ def main():
 
   host = str(sys.argv[1])
   port = int(sys.argv[2])
-  WebEngineManager.WEBENGINE_REMOTE_HOST = str(sys.argv[3]) if (len(sys.argv) > 3 and str(sys.argv[3]).strip() != "") else host
+  WebEngineManager.WEBENGINE_REMOTE_HOST = str(sys.argv[3]) if len(sys.argv) > 3 else host
   WebEngineManager.next_available_port = int(sys.argv[4]) if (len(sys.argv) > 4 and int(sys.argv[4]) != 0) else WebEngineManager.next_available_port
 
   backend_server = WSServer(host, port, RPCService)

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -38,6 +38,7 @@ from zipfile import ZipFile
 import subprocess
 import uuid
 import time
+import sys
 
 class WSServer():
   def __init__(self, _host, _port, _service_class=None):
@@ -311,7 +312,14 @@ class WebEngineManager():
     }
     
 def main():
-  backend_server = WSServer('localhost', 8081, RPCService)
+
+  if len(sys.argv) < 3:
+    print('\033[31;01mMissing required arguments: hostname and port\033[0m')
+    sys.exit(1)
+
+  host = str(sys.argv[1])
+  port = int(sys.argv[2])
+  backend_server = WSServer(host, port, RPCService)
 
   print('Starting server')
   backend_server.start_server()

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -79,7 +79,7 @@ class WSServer():
 class RPCService(WSServer.SampleRPCService):
   def __init__(self, _websocket, _path):
     super().__init__(_websocket, _path)
-    self.webengine_manager = WebEngineManager()
+    self.webengine_manager = WebEngineManager(self.websocket.host)
     self.rpc_mapping = {
       "GetPTSFileContent": self.handle_get_pts_file_content,
       "SavePTUToFile": self.handle_save_ptu_to_file,
@@ -182,7 +182,8 @@ class RPCService(WSServer.SampleRPCService):
 class WebEngineManager():
   next_available_port = 4000
   webengine_apps = {}
-  def __init__(self):
+  def __init__(self, _host):
+    self.WEBENGINE_HOST = _host
     self.storage_folder = os.path.join(os.getcwd(), 'webengine')
     if not os.path.isdir(self.storage_folder):
       print('\033[1mCreating apps storage folder\033[0m')
@@ -249,11 +250,11 @@ class WebEngineManager():
     secret_key = str(uuid.uuid4())
     print('\033[2mPort is %s, secret key is %s\033[0m' % (port, secret_key))
 
-    process = subprocess.Popen(['python3', '../../tools/file_server.py', str(port), secret_key], cwd=_app_storage_folder)
+    process = subprocess.Popen(['python3', '../../tools/file_server.py', str(self.WEBENGINE_HOST), str(port), secret_key], cwd=_app_storage_folder)
     time.sleep(1)
 
     WebEngineManager.next_available_port += 1
-    return {'process': process, 'url': 'http://localhost:%s/%s/' % (port, secret_key)}
+    return {'process': process, 'url': 'http://%s:%s/%s/' % (self.WEBENGINE_HOST, port, secret_key)}
 
   def handle_get_installed_apps(self, _method_name, _params):
     resp = self.get_installed_apps()

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -183,6 +183,8 @@ class RPCService(WSServer.SampleRPCService):
 class WebEngineManager():
   next_available_port = 4000
   webengine_apps = {}
+  WEBENGINE_REMOTE_HOST = "127.0.0.1"
+
   def __init__(self, _host):
     self.WEBENGINE_HOST = _host
     self.storage_folder = os.path.join(os.getcwd(), 'webengine')
@@ -255,7 +257,7 @@ class WebEngineManager():
     time.sleep(1)
 
     WebEngineManager.next_available_port += 1
-    return {'process': process, 'url': 'http://%s:%s/%s/' % (self.WEBENGINE_HOST, port, secret_key)}
+    return {'process': process, 'url': 'http://%s:%s/%s/' % (WebEngineManager.WEBENGINE_REMOTE_HOST, port, secret_key)}
 
   def handle_get_installed_apps(self, _method_name, _params):
     resp = self.get_installed_apps()
@@ -319,6 +321,9 @@ def main():
 
   host = str(sys.argv[1])
   port = int(sys.argv[2])
+  WebEngineManager.WEBENGINE_REMOTE_HOST = str(sys.argv[3]) if (len(sys.argv) > 3 and str(sys.argv[3]).strip() != "") else host
+  WebEngineManager.next_available_port = int(sys.argv[4]) if (len(sys.argv) > 4 and int(sys.argv[4]) != 0) else WebEngineManager.next_available_port
+
   backend_server = WSServer(host, port, RPCService)
 
   print('Starting server')


### PR DESCRIPTION
At the moment the webengine backend server only works correctly for localhost(`127.0.0.1`).

This PR adds changes for the host to be easily configured in the main function of the `start_server.py` script

To configure the host change this line
```
- backend_server = WSServer('localhost', 8081, RPCService)
+ backend_server = WSServer('<hostname>', 8081, RPCService)
```