### PR TITLE
add GetLanguage and GetSupportedLanguages responses

### DIFF
--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -151,7 +151,7 @@ class RpcFactory {
             }
         })
     }
-    static UIGetSupportedLanguagesResponse(rpc) {
+    static GetSupportedLanguagesResponse(rpc) {
         return ({
             "jsonrpc": "2.0",
             "id": rpc.id,
@@ -162,14 +162,14 @@ class RpcFactory {
             }
         })        
     }
-    static UIGetLanguageResponse(rpc, language) {
+    static GetLanguageResponse(rpc) {
         return ({
             "jsonrpc": "2.0",
             "id": rpc.id,
             "result": {
                 "method": rpc.method,
                 "code": 0,
-                "language": language
+                "language": "EN-US"
             }
         })
     }

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -92,6 +92,10 @@ class TTSController {
         switch(methodName) {
             case "IsReady":
                 return {rpc: RpcFactory.IsReadyResponse(rpc, true)}
+            case "GetSupportedLanguages":
+                return { rpc: RpcFactory.GetSupportedLanguagesResponse(rpc) }
+            case "GetLanguage":
+                return { rpc: RpcFactory.GetLanguageResponse(rpc) }
             case "GetCapabilities":
                 return {"rpc": RpcFactory.TTSGetCapabilitiesResponse(rpc)}
             case "ChangeRegistration":

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -42,6 +42,10 @@ class UIController {
         switch (methodName) {
             case "IsReady":
                 return {"rpc": RpcFactory.IsReadyResponse(rpc, true)}
+            case "GetSupportedLanguages":
+                return { rpc: RpcFactory.GetSupportedLanguagesResponse(rpc) }
+            case "GetLanguage":
+                return { rpc: RpcFactory.GetLanguageResponse(rpc) }
             case "GetCapabilities":
                 if (rpc.method.split(".")[0] === "UI") {
                     return {"rpc": RpcFactory.UIGetCapabilitiesResponse(rpc)}

--- a/src/js/Controllers/VRController.js
+++ b/src/js/Controllers/VRController.js
@@ -5,6 +5,10 @@ class VRController {
         switch(methodName) {
             case "IsReady":
                 return {rpc: RpcFactory.IsReadyResponse(rpc, true)}
+            case "GetSupportedLanguages":
+                return { rpc: RpcFactory.GetSupportedLanguagesResponse(rpc) }
+            case "GetLanguage":
+                return { rpc: RpcFactory.GetLanguageResponse(rpc) }
             case "ChangeRegistration":
                 return true
             case "AddCommand":


### PR DESCRIPTION
this PR implements the `GetLanguage` and `GetSupportedLanguages` RPCs on three interfaces, `TTS`, `VR`, and `UI`.

perhaps TTS is unnecessary but this way you can get a success response to RAI