### PR TITLE
Fix issues with OnAppPermissionConsent message in external mode

### DIFF
--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -516,13 +516,16 @@ class RpcFactory {
         }
         return (msg)         
     }
-    static OnAppPermissionConsent(consentedFunctions, externalConsentStatus) {
+    static OnAppPermissionConsent(appID, consentedFunctions, externalConsentStatus) {
         var msg = {
           'jsonrpc': '2.0',
           'method': 'SDL.OnAppPermissionConsent',
           'params': {
             'source': 'GUI'
           }
+        }
+        if(appID) {
+            msg.params.appID = appID
         }
         if(consentedFunctions) {
             msg.params.consentedFunctions = consentedFunctions


### PR DESCRIPTION
The Generic HMI was sending an empty `externalConsentStatus` parameter when sending `OnAppPermissionConsent`, which breaks the HMI spec. The value should be omitted instead. In addition, the `appID` parameter must be included in this notification.