### PR TITLE
Wait for core connection before executing fs controller startup

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,8 +121,7 @@ class HMIApp extends React.Component {
             }, 10000, this);
         }
 
-        var waitCoreInterval = setInterval(() => {
-            var sdlSocket = this.sdl.socket
+        var waitCoreInterval = setInterval((sdlSocket) => {
             if (sdlSocket.readyState === sdlSocket.OPEN) {
                 setTimeout(() => { // give time to reply to IsReady
                     FileSystemController.connect(flags.FileSystemApiUrl).then(() => {
@@ -157,7 +156,7 @@ class HMIApp extends React.Component {
                 }, 500); // setTimeout
                 clearInterval(waitCoreInterval);
             }
-        }, 500); // setInterval
+        }, 500, this.sdl.socket); // setInterval
     }
     componentWillUnmount() {
         this.sdl.disconnectFromSDL()

--- a/src/index.js
+++ b/src/index.js
@@ -125,7 +125,6 @@ class HMIApp extends React.Component {
             var sdlSocket = this.sdl.socket
             if (sdlSocket.readyState === sdlSocket.OPEN) {
                 setTimeout(() => { // give time to reply to IsReady
-                    console.log("do file controller stuff")
                     FileSystemController.connect(flags.FileSystemApiUrl).then(() => {
                         console.log('Connected to FileSystemController');
                         store.dispatch(updateAppStoreConnectionStatus(true));

--- a/src/index.js
+++ b/src/index.js
@@ -121,44 +121,44 @@ class HMIApp extends React.Component {
             }, 10000, this);
         }
 
-        FileSystemController.connect(flags.FileSystemApiUrl).then(() => {
-            console.log('Connected to FileSystemController');
-            store.dispatch(updateAppStoreConnectionStatus(true));
-            FileSystemController.onDisconnect(() => { store.dispatch(updateAppStoreConnectionStatus(false)); });
-
-            FileSystemController.subscribeToEvent('GetInstalledApps', (success, params) => {
-                if (!success || !params.apps) {
-                    console.error('error encountered when retrieving installed apps');
-                    return;
-                }
-
-                params.apps.map((app) => {
-                    FileSystemController.parseWebEngineAppManifest(app.appUrl).then((manifest) => {
-                        let appEntry = Object.assign(app, {
-                            entrypoint: manifest.entrypoint,
-                            version: manifest.appVersion
-                        });
-                        store.dispatch(updateInstalledAppStoreApps(appEntry));
-                        bcController.getAppProperties(app.policyAppID);
-                        return true;
-                    });
-                    return true;
-                });
-            });
-    
+        var waitCoreInterval = setInterval(() => {
             var sdlSocket = this.sdl.socket
-            var waitCoreInterval = setInterval(function() {
-                 // cant send rpc before core is connected
-                if (sdlSocket.readyState === sdlSocket.OPEN) {
-                    setTimeout(function () { // give time to reply to IsReady
+            if (sdlSocket.readyState === sdlSocket.OPEN) {
+                setTimeout(() => { // give time to reply to IsReady
+                    console.log("do file controller stuff")
+                    FileSystemController.connect(flags.FileSystemApiUrl).then(() => {
+                        console.log('Connected to FileSystemController');
+                        store.dispatch(updateAppStoreConnectionStatus(true));
+                        FileSystemController.onDisconnect(() => { store.dispatch(updateAppStoreConnectionStatus(false)); });
+            
+                        FileSystemController.subscribeToEvent('GetInstalledApps', (success, params) => {
+                            if (!success || !params.apps) {
+                                console.error('error encountered when retrieving installed apps');
+                                return;
+                            }
+            
+                            params.apps.map((app) => {
+                                FileSystemController.parseWebEngineAppManifest(app.appUrl).then((manifest) => {
+                                    let appEntry = Object.assign(app, {
+                                        entrypoint: manifest.entrypoint,
+                                        version: manifest.appVersion
+                                    });
+                                    store.dispatch(updateInstalledAppStoreApps(appEntry));
+                                    bcController.getAppProperties(app.policyAppID);
+                                    return true;
+                                });
+                                return true;
+                            });
+                        });
+            
                         FileSystemController.sendJSONMessage({
                             method: 'GetInstalledApps', params: {}
                         });
-                    }, 500);
-                    clearInterval(waitCoreInterval);
-                }
-            }, 500);
-        }, () => { store.dispatch(updateAppStoreConnectionStatus(false)); });
+                    }, () => { store.dispatch(updateAppStoreConnectionStatus(false)); });
+                }, 500); // setTimeout
+                clearInterval(waitCoreInterval);
+            }
+        }, 500); // setInterval
     }
     componentWillUnmount() {
         this.sdl.disconnectFromSDL()


### PR DESCRIPTION
Wraps the file system controller startup logic in a timed interval waiting for the core connection to be opened. There was a part of this block that already had a timed wait, so i applied the same approach to the entire block.