### PR TITLE
Calculate show reponse for unsupported template layout

### DIFF
--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -151,8 +151,7 @@ class RpcFactory {
     static UIShowResponse(rpc) {
         var supportedTemplates = capabilities["MEDIA"].displayCapabilities.templatesAvailable;
         const templateConfiguration = rpc.params.templateConfiguration;
-        const templateExists = templateConfiguration 
-            && templateConfiguration.template ? true : false;
+        const templateExists = templateConfiguration && templateConfiguration.template;
         // Calculated bool val if the request only tried to change the template layout
         const onlyChangeTemplate = templateConfiguration !== undefined 
             && Object.keys(rpc.params).length === 3 //appID, showStrings, templateConfiguration 

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -82,7 +82,7 @@ class UIController {
                         this.listener.send(RpcFactory.OnSystemCapabilityDisplay(templateConfiguration.template, rpc.params.appID));
                     }                    
                 }
-                return true
+                return {"rpc": RpcFactory.UIShowResponse(rpc)}
             case "SetAppIcon":
                 store.dispatch(setAppIcon(rpc.params.appID, rpc.params.syncFileName))
                 return true


### PR DESCRIPTION
In the event a template layout is not supported, the show response must calculate if the result should be a WARNINGS with info, or UNSUPPORTED_REQUEST.

Fixes #294 

Things to test

show strings only -> success
valid template only -> success
invalid template only -> unsupported failure
invalid template with show strings -> warnings success