### PR TITLE
remove div over top of shutdown and theme buttons in non-media template

### DIFF
--- a/src/css/components/_non-media.scss
+++ b/src/css/components/_non-media.scss
@@ -4,6 +4,10 @@
     @include flex-direction(column);
 }
 
+.non-media {
+    height: 0;
+}
+
 .non-media-meta-data {
     @include display(flex);
     @include flex-direction(row);


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/289

Summary

hide div containing one transformed child