### PR TITLE
remove mediaTrack from display capabilities

### DIFF
--- a/src/js/Controllers/DisplayCapabilities.js
+++ b/src/js/Controllers/DisplayCapabilities.js
@@ -155,7 +155,6 @@ let capabilities = {
 				textField("mainField3"),
 				textField("statusBar"),
 				textField("mediaClock"),
-				textField("mediaTrack"),
 				textField("templateTitle", 50),
 				textField("alertText1"),
 				textField("alertText2"),


### PR DESCRIPTION
potentially fixes https://github.com/smartdevicelink/generic_hmi/issues/317

mediaTrack text field is not used anywhere in the UI