### PR TITLE
Add ptu path flag

### DIFF
--- a/src/js/Controllers/FileSystemController.js
+++ b/src/js/Controllers/FileSystemController.js
@@ -1,4 +1,5 @@
 import SimpleRPCClient from '../SimpleRPCClient'
+import { flags } from '../Flags'
 
 class FileSystemController extends SimpleRPCClient {
     connect(url) {
@@ -99,7 +100,8 @@ class FileSystemController extends SimpleRPCClient {
     }
 
     generatePTUFilePath(){
-      let path = document.location.pathname;
+
+      let path =  flags.PTUPath ? flags.PTUPath : document.location.pathname;
       let index = path.lastIndexOf('/');
       if (index >= 0) {
         path = path.slice(0, index);

--- a/src/js/Flags.js
+++ b/src/js/Flags.js
@@ -7,7 +7,8 @@ var flags = {
     CoreHost: '127.0.0.1',
     CorePort: 8087,
     CoreWebEngineAppPort: 2020,
-    AppStoreDirectoryUrl: 'https://sdl-webengine-app-store-example.s3.amazonaws.com/app-directory.json'
+    AppStoreDirectoryUrl: 'https://sdl-webengine-app-store-example.s3.amazonaws.com/app-directory.json',
+    PTUPath: null
 };
 
 export {flags};


### PR DESCRIPTION
Add a flag to define the path where a ptu should be saved. This is needed for running the generic hmi on a website such as manticore where document.pathname is not a valid path.