### PR TITLE
Add image optimizations

### DIFF
--- a/src/js/Templates/Shared/Image.js
+++ b/src/js/Templates/Shared/Image.js
@@ -69,7 +69,6 @@ class Image extends React.Component {
                     this.canvasStyle.x = (canvas.width / 2) - (scaledDimensions.width / 2);
                     this.canvasStyle.y = (canvas.height / 2) - (scaledDimensions.height / 2);
                 }
-                }
 
                 ctx.drawImage(img, this.canvasStyle.x, this.canvasStyle.y, scaledDimensions.width, scaledDimensions.height);
 

--- a/src/js/Templates/Shared/Image.js
+++ b/src/js/Templates/Shared/Image.js
@@ -65,19 +65,13 @@ class Image extends React.Component {
 
                 ctx.clearRect(0, 0, this.canvasStyle.width, this.canvasStyle.height);
 
-                var x, y;
-
-                if (this.canvasStyle.x && this.canvasStyle.y) {
-                    x = this.canvasStyle.x;
-                    y = this.canvasStyle.y;
-                } else {
-                    x = (canvas.width / 2) - (scaledDimensions.width / 2);
-                    y = (canvas.height / 2) - (scaledDimensions.height / 2);
-                    this.canvasStyle.x = x;
-                    this.canvasStyle.y = y;
+                if (!this.canvasStyle.x || !this.canvasStyle.y) {
+                    this.canvasStyle.x = (canvas.width / 2) - (scaledDimensions.width / 2);
+                    this.canvasStyle.y = (canvas.height / 2) - (scaledDimensions.height / 2);
+                }
                 }
 
-                ctx.drawImage(img, x, y, scaledDimensions.width, scaledDimensions.height);
+                ctx.drawImage(img, this.canvasStyle.x, this.canvasStyle.y, scaledDimensions.width, scaledDimensions.height);
 
                 ctx.globalCompositeOperation = "source-atop";
                 ctx.globalAlpha = 1.0;

--- a/src/js/Templates/Shared/Image.js
+++ b/src/js/Templates/Shared/Image.js
@@ -7,6 +7,13 @@ class Image extends React.Component {
     constructor(props) {
         super(props);
         this.state = {error: false, refreshed: false};
+        this.canvasStyle = {
+            height: null,
+            width: null,
+            scaledDimensions: null,
+            x: null,
+            y: null
+        };
     }
 
     scaleImage(ogDimension, parentDimension) {
@@ -30,28 +37,52 @@ class Image extends React.Component {
             const canvas = this.refs.canvas
             const ctx = canvas.getContext("2d")
             const img = this.refs.image
-            canvas.width = canvasContainer.clientWidth
-            canvas.height = canvasContainer.clientHeight
+
+            if (this.canvasStyle.height && this.canvasStyle.width) {
+                canvas.width = this.canvasStyle.width
+                canvas.height = this.canvasStyle.height
+            } else {
+                canvas.width = canvasContainer.clientWidth
+                canvas.height = canvasContainer.clientHeight
+                this.canvasStyle.width = canvasContainer.clientWidth
+                this.canvasStyle.height = canvasContainer.clientHeight
+            }
+
             img.onload = () => {
-                var scaledDimensions = this.scaleImage({
-                        "width": img.width,
-                        "height": img.height
-                    }, {
-                        "width": canvas.width,
-                        "height": canvas.height
-                    }
-                );
+                var scaledDimensions;
+                if (this.canvasStyle.scaledDimensions) {
+                    scaledDimensions = this.canvasStyle.scaledDimensions
+                } else {
+                    scaledDimensions= this.scaleImage({
+                            "width": img.width,
+                            "height": img.height
+                        }, {
+                            "width": this.canvasStyle.width,
+                            "height": this.canvasStyle.height
+                        }
+                    );
+                }
 
-                ctx.clearRect(0, 0, canvasContainer.clientWidth, canvasContainer.clientHeight);
+                ctx.clearRect(0, 0, this.canvasStyle.width, this.canvasStyle.height);
 
-                var x = (canvas.width / 2) - (scaledDimensions.width / 2);
-                var y = (canvas.height / 2) - (scaledDimensions.height / 2);
+                var x, y;
+
+                if (this.canvasStyle.x && this.canvasStyle.y) {
+                    x = this.canvasStyle.x;
+                    y = this.canvasStyle.y;
+                } else {
+                    x = (canvas.width / 2) - (scaledDimensions.width / 2);
+                    y = (canvas.height / 2) - (scaledDimensions.height / 2);
+                    this.canvasStyle.x = x;
+                    this.canvasStyle.y = y;
+                }
+
                 ctx.drawImage(img, x, y, scaledDimensions.width, scaledDimensions.height);
 
                 ctx.globalCompositeOperation = "source-atop";
                 ctx.globalAlpha = 1.0;
                 ctx.fillStyle = fillColor;
-                ctx.fillRect(0, 0, canvasContainer.clientWidth, canvasContainer.clientHeight);
+                ctx.fillRect(0, 0, this.canvasStyle.width, this.canvasStyle.height);
 
                 ctx.globalCompositeOperation = "source-over";
                 ctx.globalAlpha = 1.0;
@@ -67,6 +98,30 @@ class Image extends React.Component {
 
     componentDidUpdate(){
         this.drawImage();
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+        // Check if any props changed
+        if (this.props.fillColor != nextProps.fillColor) {
+            return true;
+        }
+        if (this.props.image != nextProps.image) {
+            return true;
+        }
+        if (this.props.isTemplate != nextProps.isTemplate) {
+            return true;
+        }
+        if (this.props.class != nextProps.class) {
+            return true;
+        }
+
+        // Check if next image is to be refreshed
+        if (nextProps.refreshImage == nextProps.image) {
+            return true;
+        }
+        
+        // No updates required
+        return false;
     }
 
     onError(event) {
@@ -96,10 +151,19 @@ class Image extends React.Component {
         if(this.props.image && !this.state.error) {
             if(this.props.isTemplate) {
                 var hidden = {display:'none'};
-                var size = {
-                    height: "100%",
-                    width: "100%"
+                var size;
+                if (this.canvasStyle.height && this.canvasStyle.width) {
+                    size = {
+                        height: this.canvasStyle.height,
+                        width: this.canvasStyle.width
+                    }
+                } else {
+                    size = {
+                        height: "100%",
+                        width: "100%"
+                    }
                 }
+
                 return (
                     <div style={size} ref="canvasContainer">
                         <canvas ref="canvas" className={this.props.class}/>


### PR DESCRIPTION
Fixes #293 

Adds some optimizations to the image component. 

1. Adds shouldComponentUpdate lifecycle method. This should prevent images from unneccesarily updating when no props have changed. This especially helps with template images since it prevents the canvas from being redrawn unnecessarily. 

2. Storing calculated canvas style properties. This point more-so addresses the issue in #293. For some unknown reason on Safari 14, the calculated canvas height kept growing causing images to shift downward. The calculated styles for the canvas are now only calculated once and stored.