### PR TITLE
Ignore GetVehicleData

### DIFF
--- a/src/js/Controllers/VehicleInfoController.js
+++ b/src/js/Controllers/VehicleInfoController.js
@@ -7,6 +7,8 @@ class VehicleInfoController {
                 return {rpc: RpcFactory.IsReadyResponse(rpc, true)}
             case "GetVehicleType":
                 return {rpc: RpcFactory.GetVehicleType(rpc)}
+            case "GetVehicleData": 
+                return null
             default:
                 return false;
         }


### PR DESCRIPTION
Causing issues with manticore because the Generic HMI was immediately responding with Generic Error. This change makes the generic hmi ignore the request so the vehicle data component of manticore can respond instead.