### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,36 @@
+---
+name: ISSUE_TEMPLATE
+about: 'Reporting an Issue '
+title: " "
+labels: ''
+assignees: ''
+
+---
+
+[Delete any non-applicable sections, but we may ask for more information. Please reference the [SmartDeviceLink GitHub Best Practices](https://d83tozu1c8tt6.cloudfront.net/media/resources/SDL_GitHub_BestPractices.pdf) for further instructions on how to enter an issue.]
+
+### Bug Report
+[Summary]
+
+##### Reproduction Steps
+1. [Step 1]
+2. [Step 2]
+3. [Step 3]
+
+##### Expected Behavior
+[Some expected behavior]
+
+##### Observed Behavior
+[Some observed behavior]
+
+##### Browser & Version Information
+* Browser and Version:[What browser is being used including its version are you using when the bug occurred]
+* RPC Sent: [Exact RPC you were sending when you saw this issue]
+* Output Received: [What response did you receive from the RPC sent]
+* Generic HMI Version: [What version of the HMI has this bug been seen on]
+* Testing Against: [What you tested with to observe this behavior]
+
+##### Test Case, Sample Code, and / or Example App
+[Paste a link to a PR, gist, or other code that exemplifies this behavior]
+
+[Paste a link to a PR, gist, or other code that exemplifies this behavior]


### PR DESCRIPTION
Fixes: https://github.com/smartdevicelink/generic_hmi/issues/340

The generic_hmi issue template is not showing up when I go to make a new issue.