### PR TITLE
[SDL-0293] Enable OEM exclusive apps support

### DIFF
--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -330,6 +330,7 @@ class RpcFactory {
                 "ccpu_version": "0.0.1",
                 "language": "EN-US",
                 "wersCountryCode": "WAEGB",
+                "systemHardwareVersion": "123.456.789",
             }
         })
     }

--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -330,7 +330,7 @@ class RpcFactory {
                 "ccpu_version": "0.0.1",
                 "language": "EN-US",
                 "wersCountryCode": "WAEGB",
-                "systemHardwareVersion": "123.456.789",
+                "systemHardwareVersion": "123.456.789"
             }
         })
     }


### PR DESCRIPTION
Fixes #333

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR
- [x] I have tested this PR against Core and verified behavior

#### Core Tests
* `systemHardwareVersion` parameter is present in `RegisterAppInterface` response, and the value corresponds to the one defined in generic HMI

Core version / branch / commit hash / module tested against: [LuxoftSDL/sdl_core#sdl_0293_enable_oem_exclusive_apps_support](https://github.com/LuxoftSDL/sdl_core/tree/feature/sdl_0293_enable_oem_exclusive_apps_support)
Proxy+Test App name / version / branch / commit hash / module tested against: [smartdevicelink/sdl_javascript_suite](https://github.com/smartdevicelink/sdl_javascript_suite) + hello-sdl

### Summary
Applied [[SDL-0293] Enable OEM exclusive apps support](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0293-vehicle-type-filter.md) changes

### Changelog
##### Breaking Changes
* `N/A`

##### Enhancements
* Added `systemHardwareVersion` parameter to `BCGetSystemInfoResponse`

##### Bug Fixes
* `N/A`

### Tasks Remaining:
- `N/A`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
