### PR TITLE
Add timer offset logic to handle RESUME event

### DIFF
--- a/src/js/MediaTrackInfo.js
+++ b/src/js/MediaTrackInfo.js
@@ -23,7 +23,8 @@ export default class MediaTrackInfo extends React.Component {
     render() {
         var startDate = this.props.startDate
         var endDate = this.props.endDate
-        var now = this.props.pauseTime ? this.props.pauseTime : new Date().getTime()
+        var offset = this.props.offset
+        var now = new Date().getTime()
         switch (this.props.updateMode) {
             case "PAUSE":
                 clearInterval(this.interval)
@@ -42,15 +43,17 @@ export default class MediaTrackInfo extends React.Component {
         if (startDate) {
             var timeSince = null;
             if (this.props.countDirection === "COUNTDOWN") {
+                var startPosition = new Date(startDate.getTime() - offset)
                 timeSince = new Date((now - this.props.updateTime) * this.props.countRate)
-                var position = new Date(startDate - timeSince)
+                var position = new Date(startPosition - timeSince)
 
                 // Clamp position to timer bounds
                 position = endDate && position < endDate ? endDate : position
                 var endTime = ""
             }
             else {
-                timeSince = new Date(startDate.getTime() + ((now - this.props.updateTime) * this.props.countRate))
+                startPosition = new Date(startDate.getTime() + offset)
+                timeSince = new Date(startPosition.getTime() + ((now - this.props.updateTime) * this.props.countRate))
                 // Clamp position to timer bounds
                 position = endDate && timeSince > endDate ? endDate : timeSince
 
@@ -62,6 +65,10 @@ export default class MediaTrackInfo extends React.Component {
                 if(endHours === "00" && endMins === "00" && endSecs === "00") {
                     endTime = ""
                 }
+            }
+
+            if (this.props.paused) {
+                position = startPosition
             }
 
             var startHours = position.getHours() < 10 ? "0" + position.getHours() : position.getHours()

--- a/src/js/ProgressBar.js
+++ b/src/js/ProgressBar.js
@@ -37,7 +37,8 @@ export default class ProgressBar extends React.Component {
     render() {
         var startDate = this.props.startDate
         var endDate = this.props.endDate
-        var now = this.props.pauseTime ? this.props.pauseTime : new Date().getTime()
+        var offset = this.props.offset
+        var now = new Date().getTime()
         switch (this.props.updateMode) {
             case "PAUSE":
             case "CLEAR":
@@ -54,15 +55,21 @@ export default class ProgressBar extends React.Component {
         }
 
         if (this.props.countDirection === "COUNTDOWN") {
+            var startPosition = new Date(startDate.getTime() - offset)
             var timeSince = new Date((now - this.props.updateTime) * this.props.countRate)
-            var position = new Date(startDate - timeSince)
+            var position = new Date(startPosition  - timeSince)
             position = position < endDate ? endDate : position
             var endPosition = startDate
         }
         else {
-            timeSince = new Date(startDate.getTime() + ((now - this.props.updateTime) * this.props.countRate))
+            startPosition = new Date(startDate.getTime() + offset)
+            timeSince = new Date(startPosition.getTime() + ((now - this.props.updateTime) * this.props.countRate))
             position = timeSince > endDate ? endDate : timeSince
             endPosition = endDate
+        }
+
+        if (this.props.paused) {
+            position = startPosition
         }
 
         let progressStyle = {

--- a/src/js/containers/MediaTrackInfo_c.js
+++ b/src/js/containers/MediaTrackInfo_c.js
@@ -14,7 +14,6 @@ const mapStateToProps = (state) => {
     }
     var startDate = startTime ? new Date(0, 0, 0, startTime.hours, startTime.minutes, startTime.seconds, 0) : null
     var endDate = new Date(0, 0, 0, endTime.hours, endTime.minutes, endTime.seconds, 0)
-    var offset = app.timerOffset
 
     //Assign color scheme to props
     var theme = state.theme
@@ -36,7 +35,7 @@ const mapStateToProps = (state) => {
         countDirection: app.countDirection,
         countRate: app.countRate,
         updateTime: app.updateTime,
-        offset: offset,
+        offset: app.timerOffset,
         paused: app.paused,
         colorScheme: colorScheme
     }

--- a/src/js/containers/MediaTrackInfo_c.js
+++ b/src/js/containers/MediaTrackInfo_c.js
@@ -14,7 +14,7 @@ const mapStateToProps = (state) => {
     }
     var startDate = startTime ? new Date(0, 0, 0, startTime.hours, startTime.minutes, startTime.seconds, 0) : null
     var endDate = new Date(0, 0, 0, endTime.hours, endTime.minutes, endTime.seconds, 0)
-    var offset = app.timerOffset ? app.timerOffset : 0
+    var offset = app.timerOffset
 
     //Assign color scheme to props
     var theme = state.theme

--- a/src/js/containers/MediaTrackInfo_c.js
+++ b/src/js/containers/MediaTrackInfo_c.js
@@ -14,6 +14,7 @@ const mapStateToProps = (state) => {
     }
     var startDate = startTime ? new Date(0, 0, 0, startTime.hours, startTime.minutes, startTime.seconds, 0) : null
     var endDate = new Date(0, 0, 0, endTime.hours, endTime.minutes, endTime.seconds, 0)
+    var offset = app.timerOffset ? app.timerOffset : 0
 
     //Assign color scheme to props
     var theme = state.theme
@@ -35,7 +36,8 @@ const mapStateToProps = (state) => {
         countDirection: app.countDirection,
         countRate: app.countRate,
         updateTime: app.updateTime,
-        pauseTime: app.pauseTime,
+        offset: offset,
+        paused: app.paused,
         colorScheme: colorScheme
     }
 }

--- a/src/js/containers/ProgressBar_c.js
+++ b/src/js/containers/ProgressBar_c.js
@@ -18,7 +18,7 @@ const mapStateToProps = (state) => {
     }
     var startDate = new Date(0, 0, 0, startTime.hours, startTime.minutes, startTime.seconds, 0)
     var endDate = new Date(0, 0, 0, endTime.hours, endTime.minutes, endTime.seconds, 0)
-    var offset = app.timerOffset ? app.timerOffset : 0
+    var offset = app.timerOffset
 
     //Assign color scheme to props
     var theme = state.theme

--- a/src/js/containers/ProgressBar_c.js
+++ b/src/js/containers/ProgressBar_c.js
@@ -18,6 +18,7 @@ const mapStateToProps = (state) => {
     }
     var startDate = new Date(0, 0, 0, startTime.hours, startTime.minutes, startTime.seconds, 0)
     var endDate = new Date(0, 0, 0, endTime.hours, endTime.minutes, endTime.seconds, 0)
+    var offset = app.timerOffset ? app.timerOffset : 0
 
     //Assign color scheme to props
     var theme = state.theme
@@ -49,7 +50,8 @@ const mapStateToProps = (state) => {
         countDirection: app.countDirection,
         countRate: app.countRate,
         updateTime: app.updateTime,
-        pauseTime: app.pauseTime,
+        offset: offset,
+        paused: app.paused,
         colorScheme: colorScheme
     }
 }

--- a/src/js/containers/ProgressBar_c.js
+++ b/src/js/containers/ProgressBar_c.js
@@ -18,7 +18,6 @@ const mapStateToProps = (state) => {
     }
     var startDate = new Date(0, 0, 0, startTime.hours, startTime.minutes, startTime.seconds, 0)
     var endDate = new Date(0, 0, 0, endTime.hours, endTime.minutes, endTime.seconds, 0)
-    var offset = app.timerOffset
 
     //Assign color scheme to props
     var theme = state.theme
@@ -50,7 +49,7 @@ const mapStateToProps = (state) => {
         countDirection: app.countDirection,
         countRate: app.countRate,
         updateTime: app.updateTime,
-        offset: offset,
+        offset: app.timerOffset,
         paused: app.paused,
         colorScheme: colorScheme
     }

--- a/src/js/reducers.js
+++ b/src/js/reducers.js
@@ -33,7 +33,8 @@ function newAppState () {
         audioStreamingIndicator: "PLAY_PAUSE",
         countRate: 1.0,
         updateTime: new Date().getTime(),
-        pauseTime: null,
+        timerOffset: null,
+        paused: false,
         isDisconnected: false,
         displayLayout:  null,
         alert: {
@@ -447,6 +448,7 @@ function ui(state = {}, action) {
                 }
                 app.countDirection = action.updateMode
                 app.updateTime = new Date().getTime()
+                app.timerOffset = null
             }
             else if (action.updateMode === "COUNTDOWN") {
                 if (action.updateMode !== app.countDirection) {
@@ -454,31 +456,37 @@ function ui(state = {}, action) {
                 }
                 app.countDirection = action.updateMode
                 app.updateTime = new Date().getTime()
+                app.timerOffset = null
             }
             else if (action.updateMode === "PAUSE" && action.startTime) {
-                app.pauseTime = new Date().getTime()
-                app.updateTime = app.pauseTime
+                app.updateTime = new Date().getTime()
             }
-            else if (action.updateMode === "PAUSE" && !app.pauseTime) {
-                app.pauseTime = new Date().getTime()
-            }
-            else if (action.updateMode === "RESUME" && app.pauseTime) {
+            else if (action.updateMode === "PAUSE" && !app.paused) {
                 var now = new Date().getTime()
-                app.updateTime = app.updateTime + now - app.pauseTime
+                var offset = app.timerOffset ? app.timerOffset : 0
+                app.timerOffset = new Date(offset + (now - app.updateTime) * app.countRate).getTime()
+            }
+            else if (action.updateMode === "RESUME" && app.paused) {
+                app.updateTime = new Date().getTime()
+            }
+            else if (action.updateMode === "RESUME" && !app.paused) {
+                now = new Date().getTime()
+                offset = app.timerOffset ? app.timerOffset : 0
+                app.timerOffset = new Date(offset + (now - app.updateTime) * app.countRate).getTime()
+                app.updateTime = now
             }
             else if (action.updateMode === "CLEAR") {
                 app.updateTime = new Date().getTime()
                 app.startTime = null
                 app.endTime = null
+                app.timerOffset = null
             }
             app.updateMode = action.updateMode
             if (action.audioStreamingIndicator) {
                 app.audioStreamingIndicator = action.audioStreamingIndicator
             }
             app.countRate = action.countRate ? action.countRate : 1.0
-            if (action.updateMode !== "PAUSE") {
-                app.pauseTime = null
-            }
+            app.paused = (action.updateMode === "PAUSE")
             return newState
         case Actions.SET_TEMPLATE_CONFIGURATION:
             switch(action.displayLayout) {

--- a/src/js/reducers.js
+++ b/src/js/reducers.js
@@ -33,7 +33,7 @@ function newAppState () {
         audioStreamingIndicator: "PLAY_PAUSE",
         countRate: 1.0,
         updateTime: new Date().getTime(),
-        timerOffset: null,
+        timerOffset: 0,
         paused: false,
         isDisconnected: false,
         displayLayout:  null,
@@ -448,7 +448,7 @@ function ui(state = {}, action) {
                 }
                 app.countDirection = action.updateMode
                 app.updateTime = new Date().getTime()
-                app.timerOffset = null
+                app.timerOffset = 0
             }
             else if (action.updateMode === "COUNTDOWN") {
                 if (action.updateMode !== app.countDirection) {
@@ -456,30 +456,28 @@ function ui(state = {}, action) {
                 }
                 app.countDirection = action.updateMode
                 app.updateTime = new Date().getTime()
-                app.timerOffset = null
+                app.timerOffset = 0
             }
             else if (action.updateMode === "PAUSE" && action.startTime) {
                 app.updateTime = new Date().getTime()
             }
             else if (action.updateMode === "PAUSE" && !app.paused) {
                 var now = new Date().getTime()
-                var offset = app.timerOffset ? app.timerOffset : 0
-                app.timerOffset = new Date(offset + (now - app.updateTime) * app.countRate).getTime()
+                app.timerOffset = new Date(app.timerOffset + (now - app.updateTime) * app.countRate).getTime()
             }
             else if (action.updateMode === "RESUME" && app.paused) {
                 app.updateTime = new Date().getTime()
             }
             else if (action.updateMode === "RESUME" && !app.paused) {
                 now = new Date().getTime()
-                offset = app.timerOffset ? app.timerOffset : 0
-                app.timerOffset = new Date(offset + (now - app.updateTime) * app.countRate).getTime()
+                app.timerOffset = new Date(app.timerOffset + (now - app.updateTime) * app.countRate).getTime()
                 app.updateTime = now
             }
             else if (action.updateMode === "CLEAR") {
                 app.updateTime = new Date().getTime()
                 app.startTime = null
                 app.endTime = null
-                app.timerOffset = null
+                app.timerOffset = 0
             }
             app.updateMode = action.updateMode
             if (action.audioStreamingIndicator) {


### PR DESCRIPTION
Fixes issue with #329 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
- Sending multiple PAUSE and RESUME events with different playback rates
- Sending multiple RESUME events in a row with different playback rates

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: RPC Builder App JS, master

### Summary
Adds proper logic for resuming timer by storing the timer offset when a pause/resume event is received

### Changelog
##### Bug Fixes
* Fixes SetMediaClockTimer behavior when a RESUME event is received with a specific countRate

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
