### PR TITLE
Fix sizing of shadow for non-square images

### DIFF
--- a/src/css/components/_album-art.scss
+++ b/src/css/components/_album-art.scss
@@ -4,11 +4,11 @@
     @if $calc-width <= $calc-height {
         $size: $calc-width + ($calc-width / 6.5);
         @include size($size);
-        @include transform(translateY(1%));
+        @include transform(translateY(2%));
     } @else {
         $size: $calc-height + ($calc-height / 6.5);
         @include size($size);
-        @include transform(translateY(1%));
+        @include transform(translateY(2%));
     }
 }
 

--- a/src/js/AlbumArt.js
+++ b/src/js/AlbumArt.js
@@ -29,11 +29,12 @@ export default class AlbumArt extends React.Component {
 
                 return (
                     <div className="album-art">
-                        <div style={style} className="th-box-shadow">
+                        <div style={style}>
                             <Image
                                 image={this.props.image} 
                                 isTemplate={this.props.isTemplate}
-                                fillColor={fillColor}/>
+                                fillColor={fillColor}
+                                class="th-box-shadow"/>
                         </div>    
                     </div>
                 )


### PR DESCRIPTION

Fixes #339 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Tested media template graphic with images of various aspect ratios

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: RPC Builder, master

### Summary
The image shadow for the media template graphic would remain a consistent size regardless of the aspect ratio of the image. This PR fixes the CSS to make it so the shadow matches the size of the graphic directly.

### Changelog
##### Bug Fixes
* Fixed sizing of media graphic shadow for non-square images

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
