### PR TITLE
Fix/UI.OnDriverDistraction notification for DD toggle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,8 @@ import store from './js/store'
 import Controller from './js/Controllers/Controller'
 import FileSystemController from './js/Controllers/FileSystemController';
 import bcController from './js/Controllers/BCController'
+import uiController from './js/Controllers/UIController'
+
 import {
     setTheme, 
     setPTUWithModem, 
@@ -68,7 +70,9 @@ class HMIApp extends React.Component {
         store.dispatch(setPTUWithModem(!this.props.ptuWithModemEnabled))
     }
     handleDDToggle(){
-        store.dispatch(setDDState(!this.props.dd));
+        let newDDState = !this.props.dd;
+        store.dispatch(setDDState(newDDState));
+        uiController.onDriverDistraction((newDDState) ? "DD_ON" : "DD_OFF");
     }
     render() {
         const themeClass = this.state.dark ? 'dark-theme' : 'light-theme';

--- a/src/js/Controllers/Controller.js
+++ b/src/js/Controllers/Controller.js
@@ -145,15 +145,7 @@ export default class Controller {
 
         this.send(onSystemTimeReady);
 
-        var onDriverDistraction = {
-            "jsonrpc": "2.0",
-            "method": "UI.OnDriverDistraction",
-            "params": {
-                "state": "DD_OFF"
-            }
-        }
-
-        this.send(onDriverDistraction);
+        uiController.onDriverDistraction("DD_OFF");
     }
     handleRPC(rpc) {
         var response = undefined

--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -731,6 +731,16 @@ class RpcFactory {
         })
     }
 
+    static OnDriverDistraction(ddState) {
+        return ({
+            'jsonrpc': '2.0',
+            'method': 'UI.OnDriverDistraction',
+            'params': {
+              'state': ddState,
+            }
+        })
+    }
+
     static OnUpdateSubMenu(appID, menuID) {
         return ({
             "jsonrpc": "2.0",

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -587,6 +587,10 @@ class UIController {
         this.listener.send(RpcFactory.OnUpdateSubMenu(appID, menuID))
     }
 
+    onDriverDistraction(ddState) {
+        this.listener.send(RpcFactory.OnDriverDistraction(ddState))
+    }
+
     onKeyboardInput(value, event) {
         this.listener.send(RpcFactory.OnKeyboardInput(value, event))
     }


### PR DESCRIPTION
Unlike the sdl hmi, the generic hmi does not send `UI.OnDriverDistraction` when the "Driver Distraction" box is checked/unchecked. This PR implements `UI.OnDriverDistraction` in the generic hmi.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).


Core version / branch / commit hash / module tested against: develop (https://github.com/smartdevicelink/sdl_core/commit/c5a11df0db66c73b2f59537102c11f0dff8427e5)
Proxy+Test App name / version / branch / commit hash / module tested against: Test Suite

### Summary
- Add RPC factory function for `UI.OnDriverDistraction`
- Add changes to send `UI.OnDriverDistraction` when the "Driver Distraction" box is checked/unchecked

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
