### PR TITLE
only fail interactions if an app is active

### DIFF
--- a/src/js/containers/AppsButton.js
+++ b/src/js/containers/AppsButton.js
@@ -20,9 +20,11 @@ const mapDispatchToProps = (dispatch) => {
                 dispatch(deactivateSubMenu(appID))
                 uiController.onSystemContext("MENU", appID)
             } else if (backLink === "/") { // app view -> app list
-                uiController.onSystemContext("MAIN", appID)
-                uiController.failInteractions()
-                bcController.onAppDeactivated("GENERAL", appID)
+                if (appID) {
+                    uiController.onSystemContext("MAIN", appID)
+                    uiController.failInteractions()
+                    bcController.onAppDeactivated("GENERAL", appID)
+                }
             } else { // menu -> app view (backLink is any of the layout names)
                 uiController.onSystemContext("MAIN", appID)
                 uiController.failInteractions()


### PR DESCRIPTION
Fixes #352

### Testing Plan
press BACK from Perform Interaction
press APPS from app screen
press APPS from app store

### Summary
only fail interactions if an app was active

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
