### PR TITLE
Fix tertiary text alignment and add width limit

### DIFF
--- a/src/css/components/_v-scroll-menu-item.scss
+++ b/src/css/components/_v-scroll-menu-item.scss
@@ -65,6 +65,7 @@
         flex: 0.5;
         margin: auto;
         align-self: flex-end;
+        max-width: 55px;
 
         svg {
             display: block;

--- a/src/css/components/_v-scroll-menu-item.scss
+++ b/src/css/components/_v-scroll-menu-item.scss
@@ -37,7 +37,7 @@
 
         div {
             width: 100%;
-            height: 100%;
+            height: 85%;
             display: flex;
             flex-direction: column;
             align-items: center;

--- a/src/js/Controllers/DisplayCapabilities.js
+++ b/src/js/Controllers/DisplayCapabilities.js
@@ -78,11 +78,11 @@ let textWithGraphicCapabilities = {
 			textField("subtleAlertSoftButtonText"),
 			textField("menuName"),
 			textField("secondaryText"),
-			textField("tertiaryText"),
+			textField("tertiaryText", 20),
 			textField("menuCommandSecondaryText"),
-			textField("menuCommandTertiaryText"),
+			textField("menuCommandTertiaryText", 20),
 			textField("menuSubMenuSecondaryText"),
-			textField("menuSubMenuTertiaryText")
+			textField("menuSubMenuTertiaryText", 20)
 		],
 		"imageFields": [
 			imageField("choiceImage", 40),
@@ -119,11 +119,11 @@ let textbuttonsWithGraphicCapabilities = {
 			textField("templateTitle", 50),
 			textField("menuName"),
 			textField("secondaryText"),
-			textField("tertiaryText"),
+			textField("tertiaryText", 20),
 			textField("menuCommandSecondaryText"),
-			textField("menuCommandTertiaryText"),
+			textField("menuCommandTertiaryText", 20),
 			textField("menuSubMenuSecondaryText"),
-			textField("menuSubMenuTertiaryText")
+			textField("menuSubMenuTertiaryText", 20)
 		],
 		"imageFields": [
 			imageField("choiceImage", 40),
@@ -185,11 +185,11 @@ let capabilities = {
 				textField("subtleAlertSoftButtonText"),
 				textField("menuName"),
 				textField("secondaryText"),
-				textField("tertiaryText"),
+				textField("tertiaryText", 20),
 				textField("menuCommandSecondaryText"),
-				textField("menuCommandTertiaryText"),
+				textField("menuCommandTertiaryText", 20),
 				textField("menuSubMenuSecondaryText"),
-				textField("menuSubMenuTertiaryText")
+				textField("menuSubMenuTertiaryText", 20)
 			],
 			"imageFields": [
 				imageField("choiceImage", 40),
@@ -260,11 +260,11 @@ let capabilities = {
 				textField("subtleAlertSoftButtonText"),
 				textField("menuName"),
 				textField("secondaryText"),
-				textField("tertiaryText"),
+				textField("tertiaryText", 20),
 				textField("menuCommandSecondaryText"),
-				textField("menuCommandTertiaryText"),
+				textField("menuCommandTertiaryText", 20),
 				textField("menuSubMenuSecondaryText"),
-				textField("menuSubMenuTertiaryText")
+				textField("menuSubMenuTertiaryText", 20)
 			],
 			"imageFields": [
 				imageField("choiceImage", 40),
@@ -335,11 +335,11 @@ let capabilities = {
 				textField("templateTitle", 50),
 				textField("menuName"),
 				textField("secondaryText"),
-				textField("tertiaryText"),
+				textField("tertiaryText", 20),
 				textField("menuCommandSecondaryText"),
-				textField("menuCommandTertiaryText"),
+				textField("menuCommandTertiaryText", 20),
 				textField("menuSubMenuSecondaryText"),
-				textField("menuSubMenuTertiaryText")
+				textField("menuSubMenuTertiaryText", 20)
 			],
 			"imageFields": [
 				imageField("choiceImage", 40),
@@ -389,11 +389,11 @@ let capabilities = {
 				textField("templateTitle", 50),
 				textField("menuName"),
 				textField("secondaryText"),
-				textField("tertiaryText"),
+				textField("tertiaryText", 20),
 				textField("menuCommandSecondaryText"),
-				textField("menuCommandTertiaryText"),
+				textField("menuCommandTertiaryText", 20),
 				textField("menuSubMenuSecondaryText"),
-				textField("menuSubMenuTertiaryText")
+				textField("menuSubMenuTertiaryText", 20)
 			],
 			"imageFields": [
 				imageField("choiceImage", 40),
@@ -444,11 +444,11 @@ let capabilities = {
 				textField("templateTitle", 50),
 				textField("menuName"),
 				textField("secondaryText"),
-				textField("tertiaryText"),
+				textField("tertiaryText", 20),
 				textField("menuCommandSecondaryText"),
-				textField("menuCommandTertiaryText"),
+				textField("menuCommandTertiaryText", 20),
 				textField("menuSubMenuSecondaryText"),
-				textField("menuSubMenuTertiaryText")
+				textField("menuSubMenuTertiaryText", 20)
 			],
 			"imageFields": [
 				imageField("choiceImage", 40),
@@ -484,11 +484,11 @@ let capabilities = {
 				textField("templateTitle", 50),
 				textField("menuName"),
 				textField("secondaryText"),
-				textField("tertiaryText"),
+				textField("tertiaryText", 20),
 				textField("menuCommandSecondaryText"),
-				textField("menuCommandTertiaryText"),
+				textField("menuCommandTertiaryText", 20),
 				textField("menuSubMenuSecondaryText"),
-				textField("menuSubMenuTertiaryText")
+				textField("menuSubMenuTertiaryText", 20)
 			],
 			"imageFields": [
 				imageField("choiceImage", 40),
@@ -537,11 +537,11 @@ let capabilities = {
 				textField("templateTitle", 50),
 				textField("menuName"),
 				textField("secondaryText"),
-				textField("tertiaryText"),
+				textField("tertiaryText", 20),
 				textField("menuCommandSecondaryText"),
-				textField("menuCommandTertiaryText"),
+				textField("menuCommandTertiaryText", 20),
 				textField("menuSubMenuSecondaryText"),
-				textField("menuSubMenuTertiaryText")
+				textField("menuSubMenuTertiaryText", 20)
 			],
 			"imageFields": [
 				imageField("choiceImage", 40),
@@ -590,7 +590,11 @@ let capabilities = {
 				textField("subtleAlertSoftButtonText"),
 				textField("menuName"),
 				textField("secondaryText"),
-				textField("tertiaryText")
+				textField("tertiaryText", 20),
+				textField("menuCommandSecondaryText"),
+				textField("menuCommandTertiaryText", 20),
+				textField("menuSubMenuSecondaryText"),
+				textField("menuSubMenuTertiaryText", 20)
 			],
 			"imageFields": [
 				imageField("choiceImage", 40),

--- a/src/js/VScrollMenuItem.js
+++ b/src/js/VScrollMenuItem.js
@@ -5,11 +5,9 @@ import {ReactComponent as IconArrowRight} from '../img/icons/icon-arrow-right.sv
 
 export default class VScrollMenuItem extends React.Component {
     render() {
-        let subMenuIndicator = this.props.menuID ? (
-                <span className="vscrollmenu-item__arrow svg-wrap" > 
-                    <IconArrowRight/>
-                </span>
-            ) : null;
+        let subMenuIndicatorStyle = this.props.menuID ? null : ({
+            display: "none"
+        });
         
         var classString = "vscrollmenu-item th-b-color th-bb-color-secondary";
 
@@ -52,7 +50,9 @@ export default class VScrollMenuItem extends React.Component {
                         <p className="t-small t-light th-f-color-secondary t-oneline">{tertiaryText}</p>
                     </div>
 
-                    {subMenuIndicator}
+                    <span className="vscrollmenu-item__arrow svg-wrap" > 
+                        <IconArrowRight style={subMenuIndicatorStyle}/>
+                    </span>
                 </div>
             </Link>
         )


### PR DESCRIPTION
### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
- Send addCommand with all text and icon parameters
- Send submenu with all text and icon parameters
- Ensure tertiary text and secondary image are aligned correctly between add command and submenu

### Summary
- Add width capability limit to tertiary text
- Fix alignment of tertiary text and secondary image for addcommands vs submenus

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
