### PR TITLE
Merge keyboard properties partially to allow for proper reset

### DIFF
--- a/src/js/reducers.js
+++ b/src/js/reducers.js
@@ -672,11 +672,17 @@ function ui(state = {}, action) {
                 if (!keyboardProperties.autoCompleteList) {
                     keyboardProperties.autoCompleteList = app.keyboardProperties.autoCompleteList;
                 }
-                if (!action.keyboardProperties.keyboardLayout) {
+                if (!keyboardProperties.keyboardLayout) {
                     keyboardProperties.keyboardLayout = app.keyboardProperties.keyboardLayout;
                 }
-                if (!action.keyboardProperties.language) {
+                if (!keyboardProperties.language) {
                     keyboardProperties.language = app.keyboardProperties.language;
+                }
+                if (!keyboardProperties.maskInputCharacters) {
+                    keyboardProperties.maskInputCharacters = app.keyboardProperties.maskInputCharacters;
+                }
+                if (!keyboardProperties.keypressMode) {
+                    keyboardProperties.keypressMode = "RESEND_CURRENT_ENTRY";
                 }
                 app.keyboardProperties = keyboardProperties
             }

--- a/src/js/reducers.js
+++ b/src/js/reducers.js
@@ -668,7 +668,7 @@ function ui(state = {}, action) {
             }
             if (action.keyboardProperties) {
                 // Merge keyboard properties
-                var keyboardProperties = action.keyboardProperties;
+                var keyboardProperties = Object.assign({}, action.keyboardProperties);
                 if (!keyboardProperties.autoCompleteList) {
                     keyboardProperties.autoCompleteList = app.keyboardProperties.autoCompleteList;
                 }

--- a/src/js/reducers.js
+++ b/src/js/reducers.js
@@ -668,8 +668,17 @@ function ui(state = {}, action) {
             }
             if (action.keyboardProperties) {
                 // Merge keyboard properties
-                app.keyboardProperties = Object.assign(
-                    app.keyboardProperties, action.keyboardProperties);
+                var keyboardProperties = action.keyboardProperties;
+                if (!keyboardProperties.autoCompleteList) {
+                    keyboardProperties.autoCompleteList = app.keyboardProperties.autoCompleteList;
+                }
+                if (!action.keyboardProperties.keyboardLayout) {
+                    keyboardProperties.keyboardLayout = app.keyboardProperties.keyboardLayout;
+                }
+                if (!action.keyboardProperties.language) {
+                    keyboardProperties.language = app.keyboardProperties.language;
+                }
+                app.keyboardProperties = keyboardProperties
             }
             return newState
         case Actions.SET_VIDEO_STREAM_CAPABILITY:


### PR DESCRIPTION

Fixes issue with #348 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Set all keyboard properties via SetGlobalProperties to non-standard values, then send ResetGlobalProperties. Keyboard should be in its default state.

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: RPC Builder JS, master

### Summary
Partially merge keyboard properties so that ResetGlobalProperties works properly.

### Changelog
##### Bug Fixes
* Only merge keyboard properties which are sent in ResetGlobalProperties

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
