### PR TITLE
App store error protection

### DIFF
--- a/src/js/AppStoreMenu.js
+++ b/src/js/AppStoreMenu.js
@@ -114,17 +114,20 @@ class AppStoreMenu extends React.Component {
                     {this.props.apps.map((app) => {
 
                         var postFixIndex = 0;
-                        while (app.package.size_decompressed_bytes > postFixSizes[postFixIndex + 1]) {
-                            postFixIndex++;
+                        var size;
+                        if (app.package && app.package.size_decompressed_bytes) {
+                            while (app.package.size_decompressed_bytes > postFixSizes[postFixIndex + 1]) {
+                                postFixIndex++;
+                            }    
+                            size = app.package.size_decompressed_bytes / postFixSizes[postFixIndex];
                         }
-
-                        var size = app.package.size_decompressed_bytes / postFixSizes[postFixIndex];
+                        var appSize = size ? size.toFixed(1).toString() + " " + postFixes[postFixIndex] : null;
 
                         return <AppStoreMenuItem key={app.policyAppID}
                             onSelect={() => this.onSelection(app.policyAppID, app.name, app.iconUrl, app.description)}
                             appIcon={app.iconUrl}
                             appName={app.name}
-                            appSize={`${size.toFixed(1)} ${postFixes[postFixIndex]}`}
+                            appSize={appSize}
                         />
                     })}
                 </div>

--- a/src/js/containers/AppsButton.js
+++ b/src/js/containers/AppsButton.js
@@ -14,7 +14,10 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
     return {
         onSelection: (appID, backLink, parentID) => {
-             if (backLink === "/inapplist" && parentID) { // submenu -> submenu
+            if (backLink === "/appstore") {
+                // Navigating back from app store menu
+                return;
+            } else if (backLink === "/inapplist" && parentID) { // submenu -> submenu
                 dispatch(activateSubMenu(appID, parentID, -1));
             } else if (backLink === "/inappmenu") { // submenu -> menu
                 dispatch(deactivateSubMenu(appID))


### PR DESCRIPTION
### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
- Webengine app store lifecycle with policy server

Core version / branch / commit hash / module tested against: develop

### Summary
Adds protection for possible undefined errors. One case for handling navigating away from the app store menu. Another fix to prevent a size calculation error in case the app.package is not present. 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
