### PR TITLE
Fix race condition with HMI PTU

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,44 +213,47 @@ class HMIApp extends React.Component {
             }, 10000, this);
         }
 
-        var sdlSocket = this.sdl.socket
         FileSystemController.connect(window.flags.FileSystemApiUrl).then(() => {
             console.log('Connected to FileSystemController');
+            store.dispatch(updateAppStoreConnectionStatus(true));
+            FileSystemController.onDisconnect(() => { store.dispatch(updateAppStoreConnectionStatus(false)); });
 
-            var waitCoreInterval = setInterval(() => {
-                if (sdlSocket.readyState === sdlSocket.OPEN) {
-                    setTimeout(() => { // give time to reply to IsReady
-                        store.dispatch(updateAppStoreConnectionStatus(true));
-                        FileSystemController.onDisconnect(() => { store.dispatch(updateAppStoreConnectionStatus(false)); });
-            
-                        FileSystemController.subscribeToEvent('GetInstalledApps', (success, params) => {
-                            if (!success || !params.apps) {
-                                console.error('error encountered when retrieving installed apps');
-                                return;
-                            }
-            
-                            params.apps.map((app) => {
-                                FileSystemController.parseWebEngineAppManifest(app.appUrl).then((manifest) => {
-                                    let appEntry = Object.assign(app, {
-                                        entrypoint: manifest.entrypoint,
-                                        version: manifest.appVersion
-                                    });
-                                    store.dispatch(updateInstalledAppStoreApps(appEntry));
-                                    bcController.getAppProperties(app.policyAppID);
-                                    return true;
-                                });
-                                return true;
-                            });
+            FileSystemController.subscribeToEvent('GetInstalledApps', (success, params) => {
+                if (!success || !params.apps) {
+                    console.error('error encountered when retrieving installed apps');
+                    return;
+                }
+
+                console.error('We got a GetInstalledApps response');
+                params.apps.map((app) => {
+                    FileSystemController.parseWebEngineAppManifest(app.appUrl).then((manifest) => {
+                        let appEntry = Object.assign(app, {
+                            entrypoint: manifest.entrypoint,
+                            version: manifest.appVersion
                         });
-            
+                        store.dispatch(updateInstalledAppStoreApps(appEntry));
+                        bcController.getAppProperties(app.policyAppID);
+                        return true;
+                    });
+                    return true;
+                });
+            });
+        }, () => { store.dispatch(updateAppStoreConnectionStatus(false)); });
+        
+        var waitCoreInterval = setInterval(() => {
+            var sdlSocket = this.sdl.socket
+            if (sdlSocket.readyState === sdlSocket.OPEN) {
+                setTimeout(() => { // give time to reply to IsReady
+                    if (FileSystemController.isConnected()) {
                         FileSystemController.sendJSONMessage({
                             method: 'GetInstalledApps', params: {}
                         });
-                    }, 500); // setTimeout
-                    clearInterval(waitCoreInterval);
-                }
-            }, 500); // setInterval
-        }, () => { store.dispatch(updateAppStoreConnectionStatus(false)); });
+                    }
+                }, 500); // setTimeout
+                clearInterval(waitCoreInterval);
+            }
+        }, 500); // setInterval
+
     }
     componentWillUnmount() {
         this.sdl.disconnectFromSDL()

--- a/src/index.js
+++ b/src/index.js
@@ -224,7 +224,6 @@ class HMIApp extends React.Component {
                     return;
                 }
 
-                console.error('We got a GetInstalledApps response');
                 params.apps.map((app) => {
                     FileSystemController.parseWebEngineAppManifest(app.appUrl).then((manifest) => {
                         let appEntry = Object.assign(app, {

--- a/src/index.js
+++ b/src/index.js
@@ -213,12 +213,13 @@ class HMIApp extends React.Component {
             }, 10000, this);
         }
 
-        var waitCoreInterval = setInterval(() => {
-            var sdlSocket = this.sdl.socket
-            if (sdlSocket.readyState === sdlSocket.OPEN) {
-                setTimeout(() => { // give time to reply to IsReady
-                    FileSystemController.connect(window.flags.FileSystemApiUrl).then(() => {
-                        console.log('Connected to FileSystemController');
+        var sdlSocket = this.sdl.socket
+        FileSystemController.connect(window.flags.FileSystemApiUrl).then(() => {
+            console.log('Connected to FileSystemController');
+
+            var waitCoreInterval = setInterval(() => {
+                if (sdlSocket.readyState === sdlSocket.OPEN) {
+                    setTimeout(() => { // give time to reply to IsReady
                         store.dispatch(updateAppStoreConnectionStatus(true));
                         FileSystemController.onDisconnect(() => { store.dispatch(updateAppStoreConnectionStatus(false)); });
             
@@ -245,11 +246,11 @@ class HMIApp extends React.Component {
                         FileSystemController.sendJSONMessage({
                             method: 'GetInstalledApps', params: {}
                         });
-                    }, () => { store.dispatch(updateAppStoreConnectionStatus(false)); });
-                }, 500); // setTimeout
-                clearInterval(waitCoreInterval);
-            }
-        }, 500); // setInterval
+                    }, 500); // setTimeout
+                    clearInterval(waitCoreInterval);
+                }
+            }, 500); // setInterval
+        }, () => { store.dispatch(updateAppStoreConnectionStatus(false)); });
     }
     componentWillUnmount() {
         this.sdl.disconnectFromSDL()


### PR DESCRIPTION

HMI fix for https://github.com/smartdevicelink/sdl_core/pull/3649

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
See https://github.com/smartdevicelink/sdl_core/issues/3648

Core version / branch / commit hash / module tested against: https://github.com/smartdevicelink/sdl_core/pull/3649
Proxy+Test App name / version / branch / commit hash / module tested against: SDL Android Test Suite `feature/core_7_1_tests` branch

### Summary
FileSystemController connects after the HMI connects to Core. If an HMI PTU is requested at this time as well, it can result in a race condition where the FileSystemController is not connected in time, and the HMI PTU will fail. This changes the logic to connect the controller immediately, extra setup steps for the controller are still performed after Core is connected.

### Changelog
##### Bug Fixes
* Connect FileSystemController before connecting to Core.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
