### PR TITLE
handle case image is error and then path changes

### DIFF
--- a/src/js/Templates/Shared/Image.js
+++ b/src/js/Templates/Shared/Image.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 class Image extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {error: false, refreshed: false};
+        this.state = {errorPath: null, refreshed: false};
         this.initialCanvasDimensions = {
             height: null,
             width: null
@@ -101,7 +101,7 @@ class Image extends React.Component {
             return true;
         }
 
-        if (nextState.error) {
+        if (nextState.errorPath) {
             return true;
         }
         
@@ -115,7 +115,7 @@ class Image extends React.Component {
         if (activeApp) {
             UIController.onUpdateFile(activeApp, this.props.image);
         }
-        this.setState({error: this.props.image, refreshed: this.props.image === this.props.refreshImage});
+        this.setState({errorPath: this.props.image, refreshed: this.props.image === this.props.refreshImage});
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
@@ -127,18 +127,18 @@ class Image extends React.Component {
         // Reset error flag when the image is newly refreshed
         // checking the refreshed flag prevents multiple refreshes
         else if (!prevState.refreshed) {
-            newState.error = false
+            newState.errorPath = null
         }
         // If there was an error loading image but image path has changed,
         // remove error flag
-        if (prevState.error && prevState.error !== nextProps.image) {
-            newState.error = false;
+        if (prevState.errorPath && prevState.errorPath !== nextProps.image) {
+            newState.errorPath = null;
         }
         return newState;
     }
 
     render() {
-        if(this.props.image && !this.state.error) {
+        if(this.props.image && !this.state.errorPath) {
             if (this.props.isTemplate) {
                 var hidden = {display:'none'};
                 var size = {

--- a/src/js/Templates/Shared/Image.js
+++ b/src/js/Templates/Shared/Image.js
@@ -115,7 +115,7 @@ class Image extends React.Component {
         if (activeApp) {
             UIController.onUpdateFile(activeApp, this.props.image);
         }
-        this.setState({error: true, refreshed: this.props.image === this.props.refreshImage});
+        this.setState({error: this.props.image, refreshed: this.props.image === this.props.refreshImage});
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
@@ -128,6 +128,11 @@ class Image extends React.Component {
         // checking the refreshed flag prevents multiple refreshes
         else if (!prevState.refreshed) {
             newState.error = false
+        }
+        // If there was an error loading image but image path has changed,
+        // remove error flag
+        if (prevState.error && prevState.error !== nextProps.image) {
+            newState.error = false;
         }
         return newState;
     }


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/377

### Summary
if you set an image to a path that doesn't exist, and do not putfile it, and then change path to a valid image, the image would not previously render. this PR makes it so that when the path changes the error flag is reset

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
