### PR TITLE
use previous coordinates in touch event cancel notification

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,13 +112,16 @@ class HMIApp extends React.Component {
             return;
         }
 
+        var point = {
+            x: event.pageX - this.videoRect.x,
+            y: event.pageY - this.videoRect.y
+        };
+
+        window.lastTouch = point;
         uiController.onTouchEvent(type, [{
             id: 0,
             ts: [ parseInt(event.timeStamp) ],
-            c: [{
-                x: event.pageX - this.videoRect.x,
-                y: event.pageY - this.videoRect.y
-            }]
+            c: [ point ]
         }]);
     }
 

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -628,10 +628,7 @@ class UIController {
             this.onTouchEvent('CANCEL', [{
                 id: 0,
                 ts: [ parseInt(performance.now()) ],
-                c: [{
-                    x: 0,
-                    y: 0
-                }]
+                c: [ window.lastTouch ]
             }]);
         }
     }


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/379

### Summary
save the last touch coordinates and send them in case of cancel instead of 0,0

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
