### PR TITLE
Fix/Media skip indicators reset on app deactivation

### DIFF
--- a/src/js/Controllers/BCController.js
+++ b/src/js/Controllers/BCController.js
@@ -34,7 +34,7 @@ class BCController {
                 store.dispatch(activateApp(rpc.params.appID))
                 return true
             case "CloseApplication":
-                store.dispatch(deactivateApp(rpc.params.appID))
+                store.dispatch(deactivateApp(rpc.params.appID, "APP_CLOSED"))
                 return true
             case "OnAppRegistered":
                 if (rpc.params.application.dayColorScheme || rpc.params.application.nightColorScheme) {
@@ -58,7 +58,7 @@ class BCController {
                 }
                 return null
             case "OnAppUnregistered":
-                store.dispatch(deactivateApp(rpc.params.appID))
+                store.dispatch(deactivateApp(rpc.params.appID, "APP_UNREGISTERED"))
                 store.dispatch(unregisterApplication(rpc.params.appID, rpc.params.unexpectedDisconnect))                
                 return null
             case "OnSystemCapabilityUpdated":
@@ -169,7 +169,7 @@ class BCController {
     }
     onAppDeactivated(reason, appID) {
         this.listener.send(RpcFactory.OnAppDeactivatedNotification(reason, appID))
-        store.dispatch(deactivateApp(appID))
+        store.dispatch(deactivateApp(appID, "APP_DEACTIVATED"))
     }
     onIgnitionCycleOver() {
         this.listener.send(RpcFactory.OnIgnitionCycleOverNotification())

--- a/src/js/actions.js
+++ b/src/js/actions.js
@@ -66,10 +66,11 @@ export const activateApp = (appID) => {
     }
 }
 
-export const deactivateApp = (appID) => {
+export const deactivateApp = (appID, reason) => {
     return {
         type: Actions.DEACTIVATE_APP,
-        appID: appID
+        appID: appID,
+        reason: reason
     }
 }
 

--- a/src/js/reducers.js
+++ b/src/js/reducers.js
@@ -692,8 +692,10 @@ function ui(state = {}, action) {
             app.videoStreamingCapability = action.capability
             return newState
         case Actions.DEACTIVATE_APP:
-            app.backSeekIndicator = {type: "TRACK", seekTime: null}
-            app.forwardSeekIndicator = {type: "TRACK", seekTime: null}
+            if (action.reason === "APP_CLOSED" || action.reason === "APP_UNREGISTERED"){
+                app.backSeekIndicator = {type: "TRACK", seekTime: null}
+                app.forwardSeekIndicator = {type: "TRACK", seekTime: null}    
+            }
             return newState
         case Actions.SET_HAPTIC_DATA:
             app.hapticRects = action.hapticRects;


### PR DESCRIPTION
Fixes #380 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR
- [x] I have tested this PR against Core and verified behavior

#### Core Tests
Ran issue reproduction steps

### Summary
- Add reason param for DEACTIVATE_APP action
- Added condition to reset media skip indicators only when the app is closed or unregistered

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
