### PR TITLE
Send additional resolutions in OSCU

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,8 @@ class HMIApp extends React.Component {
         var match = event.target.value.match(/(\d+)x(\d+) Scale (\d+.?\d*)/);
         var allResolutions = [JSON.parse(JSON.stringify(capabilities.COMMON.systemCapabilities.videoStreamingCapability))];
         delete allResolutions[0].additionalVideoStreamingCapabilities;
-        allResolutions.concat(capabilities.COMMON.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities);
+        allResolutions = allResolutions.concat(capabilities.COMMON.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities);
+        console.log(allResolutions);
         for (var i=0; i<allResolutions.length; i++) {
             var capability = allResolutions[i];
             var preferredResolution = capability.preferredResolution;

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,21 @@ class HMIApp extends React.Component {
     }
     pickResolution(event) {
         var match = event.target.value.match(/(\d+)x(\d+) Scale (\d+.?\d*)/);
+        var allResolutions = [JSON.parse(JSON.stringify(capabilities.COMMON.videoStreamingCapability))];
+        delete allResolutions[0].additionalVideoStreamingCapabilities;
+        allResolutions.concat(capabilities.COMMON.videoStreamingCapability.additionalVideoStreamingCapabilities);
+        for (var i=0; i<allResolutions.length; i++) {
+            var capability = allResolutions[i];
+            var preferredResolution = capability.preferredResolution;
+            if (preferredResolution.resolutionWidth == parseInt(match[1]) &&
+                preferredResolution.resolutionHeight == parseInt(match[2]) &&
+                preferredResolution.scale == parseInt(match[3]) 
+                ) {
+                allResolutions.splice(i, 1)
+                break
+            }
+        }
+
         var capability = {
             systemCapabilityType: 'VIDEO_STREAMING',
             videoStreamingCapability: {
@@ -91,7 +106,9 @@ class HMIApp extends React.Component {
                 preferredResolution: {
                     resolutionWidth: parseInt(match[1]),
                     resolutionHeight: parseInt(match[2])
-                }
+                },
+                additionalVideoStreamingCapabilities:
+                    allResolutions
             }
         }
         this.setState({ resolution: event.target.value, scale: match[3] });

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,8 @@ import FileSystemController from './js/Controllers/FileSystemController';
 import bcController from './js/Controllers/BCController'
 import uiController from './js/Controllers/UIController'
 
+import { capabilities } from './DisplayCapabilities.js'
+
 import {
     setTheme, 
     setPTUWithModem, 

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ import FileSystemController from './js/Controllers/FileSystemController';
 import bcController from './js/Controllers/BCController'
 import uiController from './js/Controllers/UIController'
 
-import { capabilities } from './DisplayCapabilities.js'
+import { capabilities } from './js/Controllers/DisplayCapabilities.js'
 
 import {
     setTheme, 

--- a/src/index.js
+++ b/src/index.js
@@ -90,12 +90,16 @@ class HMIApp extends React.Component {
         delete allResolutions[0].additionalVideoStreamingCapabilities;
         allResolutions = allResolutions.concat(capabilities.COMMON.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities);
         console.log(allResolutions);
+        console.log(match[1])
+        console.log(match[2])
+        console.log(match[3])
         for (var i=0; i<allResolutions.length; i++) {
             var capability = allResolutions[i];
             var preferredResolution = capability.preferredResolution;
+            console.log(preferredResolution);
             if (preferredResolution.resolutionWidth == parseInt(match[1]) &&
                 preferredResolution.resolutionHeight == parseInt(match[2]) &&
-                preferredResolution.scale == parseInt(match[3]) 
+                capability.scale == parseInt(match[3]) 
                 ) {
                 allResolutions.splice(i, 1)
                 break

--- a/src/index.js
+++ b/src/index.js
@@ -86,9 +86,10 @@ class HMIApp extends React.Component {
     }
     pickResolution(event) {
         var match = event.target.value.match(/(\d+)x(\d+) Scale (\d+.?\d*)/);
-        var allResolutions = [JSON.parse(JSON.stringify(capabilities.COMMON.videoStreamingCapability))];
+        console.log(capabilities.COMMON)
+        var allResolutions = [JSON.parse(JSON.stringify(capabilities.COMMON.systemCapabilities.videoStreamingCapability))];
         delete allResolutions[0].additionalVideoStreamingCapabilities;
-        allResolutions.concat(capabilities.COMMON.videoStreamingCapability.additionalVideoStreamingCapabilities);
+        allResolutions.concat(capabilities.COMMON.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities);
         for (var i=0; i<allResolutions.length; i++) {
             var capability = allResolutions[i];
             var preferredResolution = capability.preferredResolution;

--- a/src/index.js
+++ b/src/index.js
@@ -89,14 +89,9 @@ class HMIApp extends React.Component {
         var allResolutions = [JSON.parse(JSON.stringify(capabilities.COMMON.systemCapabilities.videoStreamingCapability))];
         delete allResolutions[0].additionalVideoStreamingCapabilities;
         allResolutions = allResolutions.concat(capabilities.COMMON.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities);
-        console.log(allResolutions);
-        console.log(match[1])
-        console.log(match[2])
-        console.log(match[3])
         for (var i=0; i<allResolutions.length; i++) {
             var capability = allResolutions[i];
             var preferredResolution = capability.preferredResolution;
-            console.log(preferredResolution);
             if (preferredResolution.resolutionWidth == parseInt(match[1]) &&
                 preferredResolution.resolutionHeight == parseInt(match[2]) &&
                 capability.scale == parseInt(match[3]) 

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,6 @@ class HMIApp extends React.Component {
     }
     pickResolution(event) {
         var match = event.target.value.match(/(\d+)x(\d+) Scale (\d+.?\d*)/);
-        console.log(capabilities.COMMON)
         var allResolutions = [JSON.parse(JSON.stringify(capabilities.COMMON.systemCapabilities.videoStreamingCapability))];
         delete allResolutions[0].additionalVideoStreamingCapabilities;
         allResolutions.concat(capabilities.COMMON.systemCapabilities.videoStreamingCapability.additionalVideoStreamingCapabilities);


### PR DESCRIPTION
This PR is **ready** for review.

### Testing Plan
Activate app
Switch resolution to  480x320 via dropdown
Start stream on app
After stream starts Try to switch resolutions again, all resolutions should still be in the list.

### Summary
This is a change to prevent some undesired behavior seen with the mobile libraries of handling the OSCU notification before the stream starts. OSCU seems to overwrite the entire resolution list for the app since the app will only send back the new switched preferred resolution instead of the whole list.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
