### PR TITLE
Fix/Only send OnReceivedPolicyUpdate for request type PROPRIETARY

### DIFF
--- a/src/js/Controllers/ExternalPoliciesController.js
+++ b/src/js/Controllers/ExternalPoliciesController.js
@@ -68,7 +68,18 @@ class ExternalPoliciesController {
         this.policyUpdateRetry();
     }
     onUnpackMessage(evt) {
-        sdlController.onReceivedPolicyUpdate(evt.data)
+        let jsonData;
+        try {
+            jsonData = JSON.parse(evt.data)
+        }
+        catch {
+            console.log('ExternalPolicies: failed to parse JSON content from WSMessage');
+            return;
+        }
+
+        if(jsonData.requestType == 'PROPRIETARY'){
+            sdlController.onReceivedPolicyUpdate(jsonData.data)
+        }
     }
     pack(params) {
         this.sysReqParams = params


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_hmi/issues/560

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Run the following steps for both PROPRIETARY and EXTERNAL_PROPRIETARY

1. Send SystemRequest {requestType: "CLIMATE", fileName: "climateData.json"} from the mobile app 
2. Confirm that HMI does NOT send `SDL.OnReceivedPolicyUpdate` with "climateData.json"

Core branch: https://github.com/smartdevicelink/sdl_core/tree/fix/return_requestype_in_sample_policy_manager_response 

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
