### PR TITLE
 Add padding to Alert softbuttons and adjust size

### DIFF
--- a/src/css/components/_alert.scss
+++ b/src/css/components/_alert.scss
@@ -102,6 +102,10 @@
     padding: 15px;
 }
 
+.alert-buttons .soft-button-image-static {
+    padding: 5px;
+}
+
 .alert-button-1 {
     height: 75px;
     width: 100%;
@@ -158,4 +162,9 @@
     @include display(flex);
     @include align-items(center);
     @include justify-content(center);
+}
+
+.alert-button-4 .soft-button-image-static {
+    max-height: 50px;
+    min-width: 50px;
 }

--- a/src/css/components/_alert.scss
+++ b/src/css/components/_alert.scss
@@ -102,6 +102,8 @@
     padding: 15px;
     .soft-button-image, .soft-button-image-static {
         padding: 5px;
+        max-height: 75px;
+        min-width: 75px;
     }
 }
 

--- a/src/css/components/_alert.scss
+++ b/src/css/components/_alert.scss
@@ -100,10 +100,9 @@
     @include flex-wrap(wrap);
     @include align-items(stretch);
     padding: 15px;
-}
-
-.alert-buttons .soft-button-image-static {
-    padding: 5px;
+    .soft-button-image, .soft-button-image-static {
+        padding: 5px;
+    }
 }
 
 .alert-button-1 {
@@ -158,13 +157,12 @@
     border-width: 0.154px;
     border-style: solid;
     margin: 15px;
+    .soft-button-image, .soft-button-image-static {
+        max-height: 50px;
+        min-width: 50px;
+    }
 
     @include display(flex);
     @include align-items(center);
     @include justify-content(center);
-}
-
-.alert-button-4 .soft-button-image-static {
-    max-height: 50px;
-    min-width: 50px;
 }

--- a/src/css/components/_subtle-alert.scss
+++ b/src/css/components/_subtle-alert.scss
@@ -181,20 +181,20 @@
     @include justify-content(center);
 
     .soft-button-image {
-        max-height: 55px;
+        max-height: 48px;
         display: flex;
         align-items: center;
         padding: 5px;
     }
 
     .soft-button-image-static {
-        max-height: 55px;
+        max-height: 48px;
         max-width: 100%;
-        min-width: 55px;
+        min-width: 48px;
         padding: 5px;
 
         div svg {
-            max-height: 55px;
+            max-height: 48px;
         }
     }
 

--- a/src/css/components/_subtle-alert.scss
+++ b/src/css/components/_subtle-alert.scss
@@ -94,7 +94,7 @@
     @include flex-direction(column);
     @include align-items(center);
     flex: 10;
-    max-height: calc((#{$master-height} - 75px) / 5);
+    height: calc((#{$master-height} - 75px) / 5);
 }
 
 .h-subtleAlert-button-1 {
@@ -141,18 +141,20 @@
     @include justify-content(center);
 
     .soft-button-image {
+        max-height: 72px;
         display: flex;
         align-items: center;
-        padding: 0 5px;
+        padding: 5px;
     }
 
     .soft-button-image-static {
-        max-height: 37.5px;
+        max-height: 72px;
         max-width: 100%;
-        min-width: 37.5px;
+        min-width: 72px;
+        padding: 5px;
 
         div svg {
-            max-height: 37.5px;
+            max-height: 72px;
         }
     }
 
@@ -179,18 +181,20 @@
     @include justify-content(center);
 
     .soft-button-image {
+        max-height: 55px;
         display: flex;
         align-items: center;
-        padding: 0 5px;
+        padding: 5px;
     }
 
     .soft-button-image-static {
-        max-height: 37.5px;
+        max-height: 55px;
         max-width: 100%;
-        min-width: 37.5px;
+        min-width: 55px;
+        padding: 5px;
 
         div svg {
-            max-height: 37.5px;
+            max-height: 55px;
         }
     }
 


### PR DESCRIPTION
Fixes #369, #343

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Test alerts with 1, 2, 3, or 4 softbuttons with various combinations of text and images

Core version / branch / commit hash / module tested against: 7.1.0
Proxy+Test App name / version / branch / commit hash / module tested against: RPC Builder JS

### Summary
Adds padding to Alert softbutton images, also adjusts size of images when appropriate

### Changelog
##### Bug Fixes
* Fix style for Alert softbutton images

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
