### PR TITLE
Fix/OnResetTimeout notifcation interface name

### DIFF
--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -542,10 +542,10 @@ class RpcFactory {
             }
         })
     }
-    static OnResetTimeout(appID, methodName) {
+    static OnResetTimeout(appID, interfaceName, methodName) {
         return ({
             'jsonrpc': '2.0',
-            'method': 'BasicCommunication.OnResetTimeout',
+            'method': `${interfaceName}.OnResetTimeout`,
             'params': {
                 'appID': appID,
                 'methodName': methodName

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -595,7 +595,7 @@ class UIController {
         this.endTimes[msgID] = Date.now() + timeout;
         this.timers[msgID] = setTimeout(this.onPerformInteractionTimeout, timeout, msgID, appID)
         this.appsWithTimers[msgID] = appID
-        this.onResetTimeout("appID", "UI.OnPerformInteraction")
+        this.onResetTimeout(appID, "UI.OnPerformInteraction")
     }
 
     onResetTimeout(appID, methodName) {

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -599,7 +599,7 @@ class UIController {
     }
 
     onResetTimeout(appID, methodName) {
-        this.listener.send(RpcFactory.OnResetTimeout(appID, methodName))
+        this.listener.send(RpcFactory.OnResetTimeout(appID, "UI", methodName))
     }
 
     onUpdateFile(appID, fileName) {


### PR DESCRIPTION
Fixes #395 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Core branch  tested against: develop (https://github.com/smartdevicelink/sdl_core/commit/7fe1dc83f97632e4bf9b6d858858ed75cb4f7a26)
Proxy+Test App name tested against: RPC Builder

### Summary
- Adds `interfaceName` parameter to the `OnResetTimeout` function in RPCFactory.js
- Changes the UIController's `onResetTimeout` function to send the notification with interface name "UI"

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
