### PR TITLE
limit sending OnUpdateSubMenu to once per menu opening

### DIFF
--- a/src/js/Utils/CheckForSubmenuNeedUpdate.js
+++ b/src/js/Utils/CheckForSubmenuNeedUpdate.js
@@ -1,0 +1,19 @@
+import store from "../store";
+import uiController from "../Controllers/UIController";
+
+import SubmenuDeepFind from "./SubMenuDeepFind";
+
+// Helper function to determine if menu has any children that need to be updated
+export default function CheckForSubmenuNeedUpdate(appID, menuID) {
+    var state = store.getState();
+    var app = state.ui[appID];
+
+    var commands = 0 === menuID ? app.menu :
+        SubmenuDeepFind(app.menu, menuID, 0).subMenu.subMenu;
+
+    commands.forEach((command) => {
+        if (command.subMenu && command.subMenu.length === 0) {
+            uiController.onUpdateSubMenu(appID, command.menuID);
+        }
+    });
+}

--- a/src/js/containers/AppsButton.js
+++ b/src/js/containers/AppsButton.js
@@ -2,6 +2,7 @@ import { connect } from 'react-redux'
 import bcController from '../Controllers/BCController'
 import uiController from '../Controllers/UIController'
 import AppMenuLink from '../AppMenuLink'
+import CheckForSubmenuNeedUpdate from '../Utils/CheckForSubmenuNeedUpdate';
 
 import { activateSubMenu, deactivateSubMenu} from '../actions'
 
@@ -19,9 +20,11 @@ const mapDispatchToProps = (dispatch) => {
                 return;
             } else if (backLink === "/inapplist" && parentID) { // submenu -> submenu
                 dispatch(activateSubMenu(appID, parentID, -1));
+                CheckForSubmenuNeedUpdate(appID, parentID);
             } else if (backLink === "/inappmenu") { // submenu -> menu
                 dispatch(deactivateSubMenu(appID))
                 uiController.onSystemContext("MENU", appID)
+                CheckForSubmenuNeedUpdate(appID, 0);
             } else if (backLink === "/") { // app view -> app list
                 if (appID) {
                     uiController.onSystemContext("MAIN", appID)

--- a/src/js/containers/Menu.js
+++ b/src/js/containers/Menu.js
@@ -4,6 +4,7 @@ import HScrollMenu from '../HScrollMenu'
 import uiController from '../Controllers/UIController'
 import { activateSubMenu } from '../actions'
 import {capabilities}  from '../Controllers/DisplayCapabilities'
+import CheckForSubmenuNeedUpdate from '../Utils/CheckForSubmenuNeedUpdate';
 
 const mapStateToProps = (state) => {
     var activeApp = state.activeApp
@@ -22,11 +23,6 @@ const mapStateToProps = (state) => {
             link = '/inapplist'
             if (ddState === true && menuDepth === 1) {
                 enabled = false;
-            }
-
-            if (command.subMenu.length === 0) {
-                // Found and empty submenu, ask app to send add commands
-                uiController.onUpdateSubMenu(activeApp, command.menuID);
             }
         }
         if (command.secondaryImage && command.secondaryImage.value) {
@@ -63,6 +59,7 @@ const mapDispatchToProps = (dispatch) => {
             }
             else if (menuID) {
                 dispatch(activateSubMenu(appID, menuID, 1))
+                CheckForSubmenuNeedUpdate(appID, menuID);
             }
             else if (cmdID) {
                 uiController.onSystemContext("MAIN", appID)

--- a/src/js/containers/MenuIcon.js
+++ b/src/js/containers/MenuIcon.js
@@ -3,7 +3,7 @@ import uiController from '../Controllers/UIController'
 import AppIcon from '../AppIcon'
 import '../polyfill_find'
 import { deactivateSubMenu } from '../actions';
-
+import CheckForSubmenuNeedUpdate from '../Utils/CheckForSubmenuNeedUpdate';
 
 const mapStateToProps = (state) => {
     var activeApp = state.activeApp
@@ -29,6 +29,7 @@ const mapDispatchToProps = (dispatch) => {
             //dispatch(deactivateSubMenu(appID))
             if (path === "/inappmenu") {
                 uiController.onSystemContext("MENU", appID)
+                CheckForSubmenuNeedUpdate(appID, 0);
             } else { //user exited menu
                 uiController.onSystemContext("MAIN", appID)
             }

--- a/src/js/containers/SubMenu.js
+++ b/src/js/containers/SubMenu.js
@@ -6,6 +6,7 @@ import { deactivateSubMenu, deactivateInteraction, activateSubMenu } from '../ac
 import '../polyfill_find'
 import {capabilities} from '../Controllers/DisplayCapabilities'
 import SubmenuDeepFind from '../Utils/SubMenuDeepFind'
+import CheckForSubmenuNeedUpdate from '../Utils/CheckForSubmenuNeedUpdate';
 
 const mapStateToProps = (state) => {
     var activeApp = state.activeApp
@@ -74,10 +75,6 @@ const mapStateToProps = (state) => {
         }
         if (command.subMenu) {
             link = '/inapplist';
-            if (command.subMenu.length === 0) {
-                // Found and empty submenu, ask app to send add commands
-                uiController.onUpdateSubMenu(activeApp, command.menuID);
-            }
         } else {
             link = state.ui[activeApp].displayLayout
         }
@@ -117,6 +114,7 @@ const mapDispatchToProps = (dispatch) => {
                 dispatch(deactivateInteraction(appID))
             } else if (menuID && enabled === true) {
                 dispatch(activateSubMenu(appID, menuID, 1));
+                CheckForSubmenuNeedUpdate(appID, menuID);
             } else {
                 uiController.onSystemContext("MAIN", appID)
                 uiController.onCommand(cmdID, appID)


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/397

### Summary
Previously `OnUpdateSubMenu` was sent in the mapStateToProps function which may be called many times while viewing a menu. The logic to send `OnUpdateSubMenu` was moved to whenever a menu is opened so that this notification can be sent a maximum of once per empty sub menu per menu opening.

##### Enhancements
* Prevents duplicate notifications

### Alternatives to Consider
It would be possible to limit this notification to be sent once per menuID per app life cycle

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
