### PR TITLE
cancel interaction only applies to interactions from same app

### DIFF
--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -419,60 +419,59 @@ class UIController {
 
                 return null
             }
-            case "CancelInteraction":
+            case "CancelInteraction": {
 
-                const state2 = store.getState()
-                for(const appID in state2.ui) {
-                    const app = state2.ui[appID];
+                const state = store.getState();
+                const app = state.ui[rpc.params.appID];
 
-                    if (rpc.params.functionID === 10 && app.isPerformingInteraction
-                         && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.interactionCancelId)) {
-                        clearTimeout(this.timers[app.interactionId])
-                        delete this.timers[app.interactionId]
-                        this.listener.send(RpcFactory.UIPerformInteractionCancelledResponse(app.interactionId))
-                        store.dispatch(deactivateInteraction(rpc.params.appID))
-                        this.onSystemContext("MAIN", rpc.params.appID)
-                        return true
-                    } else if (rpc.params.functionID === 12 && app.alert.showAlert && !app.alert.isSubtle
-                         && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.alert.cancelID)) {
-                        clearTimeout(this.timers[app.alert.msgID])
-                        delete this.timers[app.alert.msgID]
-                        this.listener.send(RpcFactory.AlertAbortedResponse(app.alert.msgID))
-                        store.dispatch(closeAlert(app.alert.msgID, rpc.params.appID))
-                        const context = getNextSystemContext();
-                        this.onSystemContext(context, rpc.params.appID)
-                        return true
-                    } else if (rpc.params.functionID === 64 && app.alert.showAlert && app.alert.isSubtle
+                if (rpc.params.functionID === 10 && app.isPerformingInteraction
+                        && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.interactionCancelId)) {
+                    clearTimeout(this.timers[app.interactionId])
+                    delete this.timers[app.interactionId]
+                    this.listener.send(RpcFactory.UIPerformInteractionCancelledResponse(app.interactionId))
+                    store.dispatch(deactivateInteraction(rpc.params.appID))
+                    this.onSystemContext("MAIN", rpc.params.appID)
+                    return true
+                } else if (rpc.params.functionID === 12 && app.alert.showAlert && !app.alert.isSubtle
                         && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.alert.cancelID)) {
-                       clearTimeout(this.timers[app.alert.msgID])
-                       delete this.timers[app.alert.msgID]
-                       this.listener.send(RpcFactory.SubtleAlertErrorResponse(app.alert.msgID, 5, 'subtle alert was cancelled'))
-                       store.dispatch(closeAlert(app.alert.msgID, rpc.params.appID))
-                       const context = getNextSystemContext();
-                       this.onSystemContext(context, rpc.params.appID)
-                       return true
-                    } else if (rpc.params.functionID === 26 && app.slider.showSlider
-                        && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.slider.cancelID)) {
-                       clearTimeout(this.timers[app.slider.msgID])
-                       delete this.timers[app.slider.msgID]
-                       this.listener.send(RpcFactory.SliderAbortedResponse(app.slider.msgID))
-                       store.dispatch(closeSlider(app.alert.msgID, rpc.params.appID))
-                       const context = getNextSystemContext();
-                       this.onSystemContext(context, rpc.params.appID)
-                       return true
-                    } else if (rpc.params.functionID === 25 && app.scrollableMessage.active
-                        && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.scrollableMessage.cancelID)) {
-                      clearTimeout(this.timers[app.scrollableMessage.msgID]);
-                      delete this.timers[app.scrollableMessage.msgID];
-                      this.listener.send(RpcFactory.ScrollableMessageAbortedResponse(app.scrollableMessage.msgID));
-                      store.dispatch(closeScrollableMessage(app.alert.msgID, rpc.params.appID));
-                      const context = getNextSystemContext();
-                      this.onSystemContext(context, state2.activeApp);
-                      return true;
-                    }
+                    clearTimeout(this.timers[app.alert.msgID])
+                    delete this.timers[app.alert.msgID]
+                    this.listener.send(RpcFactory.AlertAbortedResponse(app.alert.msgID))
+                    store.dispatch(closeAlert(app.alert.msgID, rpc.params.appID))
+                    const context = getNextSystemContext();
+                    this.onSystemContext(context, rpc.params.appID)
+                    return true
+                } else if (rpc.params.functionID === 64 && app.alert.showAlert && app.alert.isSubtle
+                    && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.alert.cancelID)) {
+                    clearTimeout(this.timers[app.alert.msgID])
+                    delete this.timers[app.alert.msgID]
+                    this.listener.send(RpcFactory.SubtleAlertErrorResponse(app.alert.msgID, 5, 'subtle alert was cancelled'))
+                    store.dispatch(closeAlert(app.alert.msgID, rpc.params.appID))
+                    const context = getNextSystemContext();
+                    this.onSystemContext(context, rpc.params.appID)
+                    return true
+                } else if (rpc.params.functionID === 26 && app.slider.showSlider
+                    && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.slider.cancelID)) {
+                    clearTimeout(this.timers[app.slider.msgID])
+                    delete this.timers[app.slider.msgID]
+                    this.listener.send(RpcFactory.SliderAbortedResponse(app.slider.msgID))
+                    store.dispatch(closeSlider(app.alert.msgID, rpc.params.appID))
+                    const context = getNextSystemContext();
+                    this.onSystemContext(context, rpc.params.appID)
+                    return true
+                } else if (rpc.params.functionID === 25 && app.scrollableMessage.active
+                    && (rpc.params.cancelID === undefined || rpc.params.cancelID === app.scrollableMessage.cancelID)) {
+                    clearTimeout(this.timers[app.scrollableMessage.msgID]);
+                    delete this.timers[app.scrollableMessage.msgID];
+                    this.listener.send(RpcFactory.ScrollableMessageAbortedResponse(app.scrollableMessage.msgID));
+                    store.dispatch(closeScrollableMessage(app.alert.msgID, rpc.params.appID));
+                    const context = getNextSystemContext();
+                    this.onSystemContext(context, state.activeApp);
+                    return true;
                 }
                 
                 return { rpc: RpcFactory.UICancelInteractionIgnoredResponse(rpc) }
+            }
             case 'SendHapticData':
                 store.dispatch(setHapticData(rpc.params.appID, rpc.params.hapticRectData));
                 return { rpc: RpcFactory.UISendHapticDataSuccess(rpc) }


### PR DESCRIPTION
### Summary
Change CancelInteraction code so that an app may only cancel it's own interactions and not those of other apps.

#### Testing Plan
Cancel an interaction successfully
Try to cancel an interaction of another app (should be ignored)

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
