### PR TITLE
TTS Stop Speaking

### DIFF
--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -927,6 +927,51 @@ class RpcFactory {
             }
         });
     }
+    static TTSSpeakSuccess(id) {
+        return ({
+            jsonrpc: '2.0',
+            id: id,
+            result: {
+                code: 0,
+                method: 'TTS.Speak'
+            }
+        });
+    }
+    static TTSStopSpeakingSuccess(id) {
+        return ({
+            jsonrpc: '2.0',
+            id: id,
+            result: {
+                code: 0,
+                method: 'TTS.StopSpeaking'
+            }
+        });
+    }
+    static TTSSpeakAborted(id) {
+        return ({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {
+                "code": 5,
+                "message": "TTS Speak was stopped",
+                "data": {
+                    "method": "TTS.Speak"
+                }
+            }
+        })
+    }
+    static TTSStartedNotification() {
+        return ({
+            "jsonrpc": "2.0",
+            "method": "TTS.Started"
+        })
+    }
+    static TTSStoppedNotification() {
+        return ({
+            "jsonrpc": "2.0",
+            "method": "TTS.Stopped",
+        })
+    }
 }
 
 export default RpcFactory

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -183,12 +183,9 @@ class TTSController {
                 return true
             case "Speak":
                 if (this.speakID) {
-                    this.listener.send(RpcFactory.ErrorResponse(
-                        rpc, 
-                        4, 
-                        "Speak request already in progress"
-                    ));
-                    return null;
+                    return { 
+                        rpc: RpcFactory.ErrorResponse(rpc, 4, "Speak request already in progress")
+                    };
                 }
                 var ttsChunks = rpc.params.ttsChunks
                 this.filePlaylist = []

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -98,6 +98,7 @@ class TTSController {
 
         if (this.speechSynthesisInterval) {
             clearInterval(this.speechSynthesisInterval);
+            this.speechSynthesisInterval = null;
         }
 
         this.currentlyPlaying = "TEXT";
@@ -132,6 +133,7 @@ class TTSController {
         }
         this.filePlaylist = [];
         this.currentlyPlaying = null;
+        clearInterval(this.timers[this.speakID]);
         this.listener.send(RpcFactory.TTSStopSpeakingSuccess(stopSpeakingID));
         this.listener.send(RpcFactory.TTSSpeakAborted(speakID));
         this.listener.send(RpcFactory.TTSStoppedNotification());

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -167,10 +167,7 @@ class TTSController {
                     return null;
                 }
                 const infoString = "No active TTS";
-                this.listener.send(RpcFactory.ErrorResponse(rpc, 6, infoString))
-                return null;
-
-
+                return { rpc: RpcFactory.ErrorResponse(rpc, 6, infoString) }
             default:
                 return false;
         }

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -68,6 +68,20 @@ class TTSController {
 
         var text = this.filePlaylist[0].text;
         this.filePlaylist.shift();
+        
+        // Dont allow empty strings
+        if (!text) {
+            if(this.filePlaylist[0]) {
+                if(this.filePlaylist[0].type === "FILE") {
+                    this.playAudio();
+                } else if (this.filePlaylist[0].type === "TEXT"){
+                    this.speak();
+                }    
+            } else {
+                this.speakEnded();
+            }
+            return;
+        }
 
         var speechPlayer = new SpeechSynthesisUtterance();
 

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -147,7 +147,7 @@ class TTSController {
         }
         this.filePlaylist = [];
         this.currentlyPlaying = null;
-        clearInterval(this.timers[this.speakID]);
+        clearInterval(this.timers[speakID]);
         this.listener.send(RpcFactory.TTSStopSpeakingSuccess(stopSpeakingID));
         this.listener.send(RpcFactory.TTSSpeakAborted(speakID));
         this.listener.send(RpcFactory.TTSStoppedNotification());

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -144,6 +144,14 @@ class TTSController {
             case "SetGlobalProperties":
                 return true
             case "Speak":
+                if (this.speakID) {
+                    this.listener.send(RpcFactory.ErrorResponse(
+                        rpc, 
+                        4, 
+                        "Speak request already in progress"
+                    ));
+                    return null;
+                }
                 var ttsChunks = rpc.params.ttsChunks
                 this.filePlaylist = []
                 for (var i=0; i<ttsChunks.length; i++) {


### PR DESCRIPTION
Fixes #401 Partially

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests

Send alert with tts file that is longer than the alert timeout (putfile any music mp3). Stop speaking is sent by SDL Core if the alert hits its duration without a user interaction.

Core version / branch / commit hash / module tested against: [INSERT]
Proxy+Test App name / version / branch / commit hash / module tested against: [INSERT]

### Summary
- Adds support for stop speaking rpc
- Adds TTS.Started/Stopped notifications
- Fixes order for when TTS.Speak should be responded to.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
