### PR TITLE
Feature/BasicCommunication DecryptCertificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@ Clone the [SDL Core repository](https://github.com/smartdevicelink/sdl_core) and
 - python3 and pip
 - ffmpeg
 - ffmpeg-python
+- pyopenssl
 
 ```
 sudo apt install chromium-browser ffmpeg python3 python3-pip -y
-python3 -m pip install ffmpeg-python
+python3 -m pip install ffmpeg-python pyopenssl
 ```
 
 Check out [nvm on github](https://github.com/nvm-sh/nvm#installing-and-updating) to learn how to install and use nvm!

--- a/src/js/Controllers/BCController.js
+++ b/src/js/Controllers/BCController.js
@@ -112,6 +112,22 @@ class BCController {
                     store.dispatch(setVideoStreamingCapability(rpc.params.appID, vsc.additionalVideoStreamingCapabilities));
                 }
                 return null;
+            
+            case "DecryptCertificate": {
+                const request = rpc
+                FileSystemController.subscribeToEvent('DecryptCertificate', (success, params) => {
+                    let response = (success) ? RpcFactory.SuccessResponse(request) :
+                        RpcFactory.ErrorResponse(request, 5, "Unable to decrypt certificate")
+                    this.listener.send(response)
+                });
+                FileSystemController.sendJSONMessage({
+                    method: 'DecryptCertificate',
+                    params: {
+                        fileName: request.params.fileName
+                    }
+                });
+                return null;
+            }
             default:
                 return false;
         }

--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -23,6 +23,16 @@ class RpcFactory {
         }
         return msg;
     }
+    static SuccessResponse(rpc) {
+        return ({
+            "jsonrpc": "2.0",
+            "id": rpc.id,
+            "result": {
+                "code": 0,
+                "method": rpc.method
+            }
+        })
+    }
     static ErrorResponse(rpc, code, info) {
         return ({
             "jsonrpc": "2.0",

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -345,7 +345,7 @@ class RPCService(WSServer.SampleRPCService):
     try:
       out_file = open(crt_file_path, 'w')
       out_file.write(cert_out + key_out)
-      out_file.close
+      out_file.close()
     except Exception as e:
       return RPCService.gen_error_msg('Failed to write to certificate file {0:}'.format(e))
 

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -336,7 +336,7 @@ class RPCService(WSServer.SampleRPCService):
       file_contents = open(crt_file_path, 'r').read()
       certificate = crypto.load_certificate(crypto.FILETYPE_PEM, file_contents)
       private_key = crypto.load_privatekey(crypto.FILETYPE_PEM, file_contents,
-                      passphrase='randomPassPhrase'.encode('utf-8'))
+                      passphrase=Flags.CERT_PASS_PHRASE.encode('utf-8'))
     except Exception as e:
       return RPCService.gen_error_msg('Failed to read from certificate file {0:}'.format(e))
 
@@ -499,6 +499,7 @@ def main():
   parser.add_argument('--ws-port', type=int, required=True, help="Backend server port number")
   parser.add_argument('--video-port', type=int, default=8085, help="Video streaming server port number")
   parser.add_argument('--audio-port', type=int, default=8086, help="Audio streaming server port number")
+  parser.add_argument('--cert-passphrase', type=str, default='defaultPassPhrase', help="A secret password used to decrypt the certificate from the PT")
   parser.add_argument('--fs-port', type=int, default=4000, help="File server port number")
   parser.add_argument('--fs-uri', type=str, help="File server's URI (to be sent back to the client hmi)")
 
@@ -508,6 +509,7 @@ def main():
   Flags.FILE_SERVER_URI = args.fs_uri if args.fs_uri else 'http://%s:%s' % (Flags.FILE_SERVER_HOST, Flags.FILE_SERVER_PORT)
   Flags.VIDEO_SERVER_PORT = args.video_port
   Flags.AUDIO_SERVER_PORT = args.audio_port
+  Flags.CERT_PASS_PHRASE = args.cert_passphrase
 
   backend_server = WSServer(args.host, args.ws_port, RPCService)
 

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -34,6 +34,7 @@ import websockets
 import json
 import os
 import requests
+import base64
 from zipfile import ZipFile
 import subprocess
 import uuid
@@ -333,10 +334,11 @@ class RPCService(WSServer.SampleRPCService):
     certificate = None
     private_key = None
     try:
-      file_contents = open(crt_file_path, 'r').read()
-      certificate = crypto.load_certificate(crypto.FILETYPE_PEM, file_contents)
-      private_key = crypto.load_privatekey(crypto.FILETYPE_PEM, file_contents,
-                      passphrase=Flags.CERT_PASS_PHRASE.encode('utf-8'))
+      file_contents = open(crt_file_path, 'rb').read()
+      p12 = crypto.load_pkcs12(base64.b64decode(file_contents),
+        Flags.CERT_PASS_PHRASE.encode('utf-8'))
+      certificate = p12.get_certificate()
+      private_key = p12.get_privatekey()
     except Exception as e:
       return RPCService.gen_error_msg('Failed to read from certificate file {0:}'.format(e))
 


### PR DESCRIPTION
Partially implements #401 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

**Steps:**
1. Setup up policy server
2. Follow steps listed in https://smartdevicelink.com/en/guides/sdl-server/getting-started/security/#configurable-ca-key-and-certificate-creation (creating a CA and adding the new environment variables )
3. Build sdl_core  in `EXTERNAL_PROPRIETARY` policy mode
4. In the HMI's `deploy_server.sh` script, add the flag `--cert-passphrase <CERTIFICATE_PASSPHRASE>`,  replacing `<CERTIFICATE_PASSPHRASE>` with the pass phrase used in the policy server
5. Start HMI backend server and SDL
6. Start Generic HMI and register new app
7. Activate App

**Expected Behavior:**
- The Generic HMI should receive a `BasicCommunication.DecryptCertificate` request from SDL.
- Core logs should have entries for `PolicyHandler::OnCertificateDecrypted`

#### Core Tests
Core branch: develop (https://github.com/smartdevicelink/sdl_core/commit/b636064c70a3742a792bf0a53f2f179a9f5c1fec)
Proxy+Test App name tested against: Test Suite

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
