### PR TITLE
Ignore OACU VSCs with missing properties in BCController

### DIFF
--- a/src/js/Controllers/BCController.js
+++ b/src/js/Controllers/BCController.js
@@ -106,10 +106,14 @@ class BCController {
                 if (rpc.params.appCapability.appCapabilityType === 'VIDEO_STREAMING'
                     && rpc.params.appCapability.videoStreamingCapability) {
                     var vsc = rpc.params.appCapability.videoStreamingCapability;
-                    if (!vsc.additionalVideoStreamingCapabilities) {
-                        vsc.additionalVideoStreamingCapabilities = [];
+                    var vsCapabilities = []
+                    if (vsc.additionalVideoStreamingCapabilities) {
+                        vsCapabilities = vsc.additionalVideoStreamingCapabilities.filter((cap) => {
+                            var pR = cap.preferredResolution;
+                            return cap.scale && pR && pR.resolutionWidth && pR.resolutionHeight;
+                        });
                     }
-                    store.dispatch(setVideoStreamingCapability(rpc.params.appID, vsc.additionalVideoStreamingCapabilities));
+                    store.dispatch(setVideoStreamingCapability(rpc.params.appID, vsCapabilities));
                 }
                 return null;
             default:


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/408

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Ignore VSCs that are invalid to the resolution picker when OnAppCapabilityUpdated comes in

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
