### PR TITLE
remove MEDIA template from non-media app capabilities

### DIFF
--- a/src/js/Controllers/BCController.js
+++ b/src/js/Controllers/BCController.js
@@ -50,15 +50,18 @@ class BCController {
                 }
                 if (rpc.params.application.appType.includes("WEB_VIEW")) {
                     store.dispatch(registerApplication(rpc.params.application.appID, "web-view"));
-                    this.listener.send(RpcFactory.OnSystemCapabilityDisplay("WEB_VIEW", rpc.params.application.appID));
+                    this.listener.send(RpcFactory.OnSystemCapabilityDisplay(
+                        "WEB_VIEW", rpc.params.application.appID, rpc.params.application.isMediaApplication));
                 } else if (rpc.params.application.appType.includes("NAVIGATION")
                     || rpc.params.application.appType.includes("PROJECTION")) {
                     store.dispatch(registerApplication(rpc.params.application.appID, "nav-fullscreen-map"));
-                    this.listener.send(RpcFactory.OnSystemCapabilityDisplay("NAV_FULLSCREEN_MAP", rpc.params.application.appID));
+                    this.listener.send(RpcFactory.OnSystemCapabilityDisplay(
+                        "NAV_FULLSCREEN_MAP", rpc.params.application.appID, rpc.params.application.isMediaApplication));
                 } else {
                     var templates = rpc.params.application.isMediaApplication ? ["media","MEDIA"] : ["nonmedia","NON-MEDIA"];
                     store.dispatch(registerApplication(rpc.params.application.appID, templates[0]));
-                    this.listener.send(RpcFactory.OnSystemCapabilityDisplay(templates[1], rpc.params.application.appID));
+                    this.listener.send(RpcFactory.OnSystemCapabilityDisplay(
+                        templates[1], rpc.params.application.appID, rpc.params.application.isMediaApplication));
                 }
                 return null
             case "OnAppUnregistered":

--- a/src/js/Controllers/DisplayCapabilities.js
+++ b/src/js/Controllers/DisplayCapabilities.js
@@ -831,14 +831,13 @@ const getWindowCapability = (template, includeMedia) => {
 		textFields: templateDisplayCapability.textFields,
 		imageFields: templateDisplayCapability.imageFields,
 		imageTypeSupported: ["STATIC", "DYNAMIC"],
-		templatesAvailable: templateDisplayCapability.templatesAvailable,
+		templatesAvailable: includeMedia ? [...templateDisplayCapability.templatesAvailable,  'MEDIA'] : templateDisplayCapability.templatesAvailable,
 		buttonCapabilities: templateCapability.buttonCapabilities,
 		softButtonCapabilities: templateCapability.softButtonCapabilities,
 		menuLayoutsAvailable: templateDisplayCapability.menuLayoutsAvailable,
 		dynamicUpdateCapabilities: dynamicUpdateCapabilities,
 		keyboardCapabilities: keyboardCapabilities
 	}
-	if (includeMedia) { capability.templatesAvailable.push('MEDIA'); }
 	return capability;
 }
 

--- a/src/js/Controllers/DisplayCapabilities.js
+++ b/src/js/Controllers/DisplayCapabilities.js
@@ -20,7 +20,7 @@ let imageOnlySoftButtonCapability = {
 }
 
 let templatesAvailable = [
-	"DEFAULT", "MEDIA", "NON-MEDIA", "LARGE_GRAPHIC_WITH_SOFTBUTTONS", "LARGE_GRAPHIC_ONLY",
+	"DEFAULT", "NON-MEDIA", "LARGE_GRAPHIC_WITH_SOFTBUTTONS", "LARGE_GRAPHIC_ONLY",
 	"GRAPHIC_WITH_TEXTBUTTONS", "TEXTBUTTONS_WITH_GRAPHIC", "TEXTBUTTONS_ONLY",
 	"TEXT_WITH_GRAPHIC", "GRAPHIC_WITH_TEXT", "DOUBLE_GRAPHIC_WITH_SOFTBUTTONS", "WEB_VIEW",
 	"NAV_FULLSCREEN_MAP", "TILES_ONLY"
@@ -821,7 +821,7 @@ const keyboardCapabilities = {
 	]
 }
 
-const getWindowCapability = (template) => {
+const getWindowCapability = (template, includeMedia) => {
 	if (!template || !capabilities[template]) {
 		return null;
 	}
@@ -838,10 +838,11 @@ const getWindowCapability = (template) => {
 		dynamicUpdateCapabilities: dynamicUpdateCapabilities,
 		keyboardCapabilities: keyboardCapabilities
 	}
+	if (includeMedia) { capability.templatesAvailable.push('MEDIA'); }
 	return capability;
 }
 
-const getDisplayCapability = (template) => {
+const getDisplayCapability = (template, includeMedia=false) => {
 	var templateCapability = capabilities[template];
 	if (!templateCapability) {
 		console.log("Error: Trying to access capability for unsupported template")
@@ -850,7 +851,7 @@ const getDisplayCapability = (template) => {
 	var capability = {
 		displayName: templateCapability.displayCapabilities.displayName,
 		windowTypeSupported: [mainWindowTypeCapability],
-		windowCapabilities: [getWindowCapability(template)],
+		windowCapabilities: [getWindowCapability(template, includeMedia)],
 		screenParams: screenParams
 	}
 	return capability;

--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -230,8 +230,8 @@ class RpcFactory {
         return msg
     }
     static UIGetCapabilitiesResponse(rpc) {
-        var displayCapabilities = capabilities["MEDIA"].displayCapabilities;
-        displayCapabilities.templatesAvailable.push('MEDIA');
+        let displayCapabilities = { ...capabilities["MEDIA"].displayCapabilities };
+        displayCapabilities.templatesAvailable = [...displayCapabilities.templatesAvailable, 'MEDIA'];
         return ({
             "jsonrpc": "2.0",
             "id": rpc.id,
@@ -287,8 +287,8 @@ class RpcFactory {
         })
     }
     static UIShowResponse(rpc, isMediaApp) {
-        var supportedTemplates = capabilities["MEDIA"].displayCapabilities.templatesAvailable;
-        if (isMediaApp) { supportedTemplates.push('MEDIA'); }
+        var supportedTemplates = isMediaApp ? [ ...capabilities["MEDIA"].displayCapabilities.templatesAvailable, 'MEDIA' ]
+            : capabilities["MEDIA"].displayCapabilities.templatesAvailable;
         const templateConfiguration = rpc.params.templateConfiguration;
         const templateParamExists = templateConfiguration && templateConfiguration.template;
 
@@ -779,12 +779,12 @@ class RpcFactory {
         }
         return msg  
     }
-    static SetDisplayLayoutResponse(rpc) {
+    static SetDisplayLayoutResponse(rpc, disallowedLayout=false) {
         var layout = rpc.params.displayLayout;
         var supportedTemplates = ["DEFAULT", "MEDIA", "NON-MEDIA", "LARGE_GRAPHIC_ONLY", 
         "LARGE_GRAPHIC_WITH_SOFTBUTTONS", "GRAPHIC_WITH_TEXTBUTTONS", "TEXTBUTTONS_WITH_GRAPHIC", 
         "TEXTBUTTONS_ONLY", "TILES_ONLY", "TEXT_WITH_GRAPHIC", "GRAPHIC_WITH_TEXT", "DOUBLE_GRAPHIC_WITH_SOFTBUTTONS"];
-        if (supportedTemplates.includes(layout)) {
+        if (!disallowedLayout && supportedTemplates.includes(layout)) {
             if (layout === "DEFAULT") {
                 layout = "MEDIA"
             }
@@ -812,7 +812,8 @@ class RpcFactory {
                 "id": rpc.id,
                 "error": {
                     "code": 1,
-                    "message": "The requested layout is not supported on this HMI",
+                    "message": disallowedLayout ? 'Only MEDIA apps may use the MEDIA template'
+                        : "The requested layout is not supported on this HMI",
                     "data": {
                         "method": rpc.method
                     }

--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -230,13 +230,15 @@ class RpcFactory {
         return msg
     }
     static UIGetCapabilitiesResponse(rpc) {
+        var displayCapabilities = capabilities["MEDIA"].displayCapabilities;
+        displayCapabilities.templatesAvailable.push('MEDIA');
         return ({
             "jsonrpc": "2.0",
             "id": rpc.id,
             "result": {
                 "method": rpc.method,
                 "code": 0,
-                "displayCapabilities": capabilities["MEDIA"].displayCapabilities,
+                "displayCapabilities": displayCapabilities,
                 "audioPassThruCapabilities": capabilities["COMMON"].audioPassThruCapabilities,
                 "audioPassThruCapabilitiesList": capabilities["COMMON"].audioPassThruCapabilitiesList,
                 "pcmStreamCapabilities": capabilities["COMMON"].pcmStreamCapabilities,
@@ -284,8 +286,9 @@ class RpcFactory {
             }
         })
     }
-    static UIShowResponse(rpc) {
+    static UIShowResponse(rpc, isMediaApp) {
         var supportedTemplates = capabilities["MEDIA"].displayCapabilities.templatesAvailable;
+        if (isMediaApp) { supportedTemplates.push('MEDIA'); }
         const templateConfiguration = rpc.params.templateConfiguration;
         const templateParamExists = templateConfiguration && templateConfiguration.template;
 
@@ -311,7 +314,9 @@ class RpcFactory {
                 "id": rpc.id,
                 "error": {
                     "code": 1,
-                    "message": "The requested layout is not supported on this HMI",
+                    "message": (templateConfiguration.template === 'MEDIA'
+                        ? 'Only MEDIA apps may use the MEDIA template'
+                        : "The requested layout is not supported on this HMI"),
                     "data": {
                         "method": rpc.method
                     }
@@ -841,10 +846,10 @@ class RpcFactory {
         })
     }
 
-    static OnSystemCapabilityDisplay(template, appID) {
+    static OnSystemCapabilityDisplay(template, appID, appIsMedia) {
         var systemCapability = {
             systemCapabilityType: "DISPLAYS",
-            displayCapabilities: [getDisplayCapability(template)]
+            displayCapabilities: [getDisplayCapability(template, appIsMedia)]
         }
         return this.OnSystemCapabilityUpdated(systemCapability, appID);
     }


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/182

### Summary
When sending OnSystemCapabilityUpdated, only include MEDIA template in templatesAvailable if an app is media type.
When receiving Show request, do not allow non-media app to use template MEDIA.

SetDisplayLayout is unmodified as it is deprecated.

The issue also incorrectly requests changes to the RAI response, the capabilities in the RAI response are not App specific and should not be influenced by the app type. The capabilities in the RAI response are unchanged by this PR.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
