### PR TITLE
Hide overflow for alert text

### DIFF
--- a/src/css/components/_alert.scss
+++ b/src/css/components/_alert.scss
@@ -8,7 +8,7 @@
     width: $master-width;
     height: $master-height;
     margin: 25px;
-    z-index:1001;
+    z-index: 1001;
 }
 
 .alertModal {
@@ -26,8 +26,7 @@
     outline: none;
     padding: 20px;
     width: 85%;
-
-  }
+}
 
 
 .alert{
@@ -93,6 +92,7 @@
     text-align: center;
     p {
         overflow: hidden;
+        max-width: 100%;
     }
 }
 
@@ -121,7 +121,9 @@
     overflow: hidden;
     //align-self: flex-start;
     p {
-        height: 100%;
+        max-height: 100%;
+        max-width: 100%;
+        overflow: hidden;
     }
 
     @include display(flex);
@@ -138,7 +140,9 @@
     border-style: solid;
     margin: 15px;
     p {
-        height: 100%;
+        max-height: 100%;
+        max-width: 100%;
+        overflow: hidden;
     }
 
     @include display(flex);
@@ -157,7 +161,9 @@
     margin: 15px;
     overflow: hidden;
     p {
-        height: 100%;
+        max-height: 100%;
+        max-width: 100%;
+        overflow: hidden;
     }
 
     @include display(flex);
@@ -179,7 +185,9 @@
         min-width: 50px;
     }
     p {
-        height: 100%;
+        max-height: 100%;
+        max-width: 100%;
+        overflow: hidden;
     }
 
     @include display(flex);

--- a/src/css/components/_alert.scss
+++ b/src/css/components/_alert.scss
@@ -91,6 +91,9 @@
     height: calc((#{$master-height} - 75px) / 2);
     width: 50%;
     text-align: center;
+    p {
+        overflow: hidden;
+    }
 }
 
 .alert-buttons{
@@ -115,7 +118,11 @@
     border-width: 0.154px;
     border-style: solid;
     margin: 15px;
+    overflow: hidden;
     //align-self: flex-start;
+    p {
+        height: 100%;
+    }
 
     @include display(flex);
     @include align-items(center);
@@ -130,6 +137,9 @@
     border-width: 0.154px;
     border-style: solid;
     margin: 15px;
+    p {
+        height: 100%;
+    }
 
     @include display(flex);
     @include align-items(center);
@@ -145,6 +155,10 @@
     border-width: 0.154px;
     border-style: solid;
     margin: 15px;
+    overflow: hidden;
+    p {
+        height: 100%;
+    }
 
     @include display(flex);
     @include align-items(center);
@@ -159,9 +173,13 @@
     border-width: 0.154px;
     border-style: solid;
     margin: 15px;
+    overflow: hidden;
     .soft-button-image, .soft-button-image-static {
         max-height: 50px;
         min-width: 50px;
+    }
+    p {
+        height: 100%;
     }
 
     @include display(flex);


### PR DESCRIPTION

Fixes #269 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Test long values for alertText1/2/3 and alert softButtons, verify there is no overflow

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: RPC Builder App JS (master)

### Summary
Hide overflow for Alert text fields

### Changelog
##### Bug Fixes
* Hide overflow for Alert text fields

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
