### PR TITLE
Restrict overflow of main fields in non media template

### DIFF
--- a/src/css/components/_non-media.scss
+++ b/src/css/components/_non-media.scss
@@ -18,6 +18,7 @@
     margin-bottom: 22px;
     align-items: center;
     overflow: hidden;
+    word-break: break-all;
 }
 
 .non-media-body {

--- a/src/css/components/_non-media.scss
+++ b/src/css/components/_non-media.scss
@@ -13,10 +13,11 @@
     @include flex-direction(row);
     @include flex-wrap(wrap);
     width: 100%;
-    height: 98px;
+    height: 118px;
     margin-left: 50px;
-    margin-bottom: 42px;
+    margin-bottom: 22px;
     align-items: center;
+    overflow: hidden;
 }
 
 .non-media-body {
@@ -30,9 +31,26 @@
     text-align: center;
     margin-right: 50px;
 }
+
+.non-media-oneline {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    height: 42px;
+}
+
+.non-media-twolines {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .non-media-text-4 { 
     width: 50%;
     text-align: left;
+    align-self: flex-start;
 }
 
 .non-media-graphic {

--- a/src/js/Templates/NonMedia/NonMediaBody.js
+++ b/src/js/Templates/NonMedia/NonMediaBody.js
@@ -18,14 +18,14 @@ export default class NonMediaBody extends React.Component {
         if(textFields.length > 2) {
             for(i=0; i<textFields.length; i++) {
                 if(i < 2) {
-                    textFields[i].className = "t-large t-light th-f-color non-media-text-4"; 
+                    textFields[i].className = "t-large t-light th-f-color non-media-text-4 non-media-oneline";
                 } else {
                     textFields[i].className = "t-small t-light th-f-color-secondary non-media-text-4"; 
                 }
             }
         } else {
             if(textFields[0]) {
-                textFields[0].className = "t-large t-light th-f-color non-media-text-2"; 
+                textFields[0].className = `t-large t-light th-f-color non-media-text-2 ${textFields[1] ? 'non-media-oneline' : 'non-media-twolines'}`;
             }
             if(textFields[1]) {
                 textFields[1].className = "t-small t-light th-f-color-secondary non-media-text-2";


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/296

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Add CSS to restrict the size of the main fields so that they cannot be overflowed.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
