### PR TITLE
apply different background color to highlight softbuttons

### DIFF
--- a/src/css/base/_base.scss
+++ b/src/css/base/_base.scss
@@ -87,4 +87,8 @@ body {
     }
 }
 
+.bg-highlighted {
+    background-color: color($secondary-accent-color);
+}
+
 $base-box-shadow: 0 20px 40px 0 rgba(color(black), 0.75);

--- a/src/js/AlertButtons.js
+++ b/src/js/AlertButtons.js
@@ -34,7 +34,7 @@ export default class AlertButtons extends React.Component {
 
         if(softButtons.length === 1) {
             items = softButtons.map((softButton, index) => {               
-                return (<div className={`${this.props.classPrefix}-button-1 th-f-color t-small t-light th-bg-color th-soft-buttons`}
+                return (<div className={`${this.props.classPrefix}-button-1 th-f-color t-small t-light th-soft-buttons ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
                             key={softButton.softButtonID}
                             onClick={() => this.getAction(softButton)}>
                                 <p>{softButton.text}</p>
@@ -47,7 +47,7 @@ export default class AlertButtons extends React.Component {
             })
         } else if (softButtons.length === 2) {
             items = softButtons.map((softButton, index) => {
-                return (<div className={`${this.props.classPrefix}-button-2 th-f-color t-small t-light th-bg-color th-soft-buttons`}
+                return (<div className={`${this.props.classPrefix}-button-2 th-f-color t-small t-light th-soft-buttons ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
                             key={softButton.softButtonID}
                             onClick={() => this.getAction(softButton)}>
                                 <p>{softButton.text}</p>
@@ -60,7 +60,7 @@ export default class AlertButtons extends React.Component {
             })
         } else if (softButtons.length === 3) {
             items = softButtons.map((softButton, index) => {
-                return (<div className={`${this.props.classPrefix}-button-3 th-f-color t-small t-light th-bg-color th-soft-buttons`}
+                return (<div className={`${this.props.classPrefix}-button-3 th-f-color t-small t-light th-soft-buttons ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
                             key={softButton.softButtonID}
                             onClick={() => this.getAction(softButton)}>
                                 <p>{softButton.text}</p>
@@ -73,7 +73,7 @@ export default class AlertButtons extends React.Component {
             })            
         } else if (softButtons.length === 4) {
             items = softButtons.map((softButton, index) => {
-                return (<div className={`${this.props.classPrefix}-button-4 th-f-color t-small t-light th-bg-color th-soft-buttons`}
+                return (<div className={`${this.props.classPrefix}-button-4 th-f-color t-small t-light th-soft-buttons ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
                             key={softButton.softButtonID}
                             onClick={() => this.getAction(softButton)}>
                                 <p>{softButton.text}</p>

--- a/src/js/ScrollableMessageButtons.js
+++ b/src/js/ScrollableMessageButtons.js
@@ -26,7 +26,7 @@ export default class ScrollableMessageButtons extends React.Component {
         return (
             <div className={`scrollableMessage-buttons`}>
                 {softButtons.map((softButton, index) => {
-                    return (<div className={`scrollableMessage-button th-f-color t-small t-light th-bg-color th-soft-buttons`}
+                    return (<div className={`scrollableMessage-button th-f-color t-small t-light th-soft-buttons ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
                                 key={softButton.softButtonID}
                                 onClick={() => this.getAction(softButton)}>
                                     <SoftButtonImage image={softButton.image ? softButton.image.value : null}

--- a/src/js/Templates/Shared/SoftButtons.js
+++ b/src/js/Templates/Shared/SoftButtons.js
@@ -49,7 +49,8 @@ class SoftButtonsBody extends React.Component {
 
         if(softButtons.length === 1) {
             items = softButtons.map((softButton, index) => {
-                return (<div className="soft-button-tile-large th-f-color t-small t-light th-bg-color th-soft-buttons soft-button" style={cssColorStyle}
+                return (<div className={`soft-button-tile-large th-f-color t-small t-light th-soft-buttons soft-button ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
+                            style={cssColorStyle}
                             key={softButton.softButtonID}
                             /*onClick={() => this.props.onButtonPress(this.props.appID, softButton.softButtonID, "CUSTOM_BUTTON")}*/
                             onMouseDown={() => mouseDown(softButton)}
@@ -65,7 +66,8 @@ class SoftButtonsBody extends React.Component {
             })
         } else if (softButtons.length === 2) {
             items = softButtons.map((softButton, index) => {
-                return (<div className="soft-button-tile-wide-large th-f-color t-small t-light th-bg-color th-soft-buttons soft-button" style={cssColorStyle}
+                return (<div className={`soft-button-tile-wide-large th-f-color t-small t-light th-soft-buttons soft-button ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
+                            style={cssColorStyle}
                             key={softButton.softButtonID}
                             /*onClick={() => this.props.onButtonPress(this.props.appID, softButton.softButtonID, "CUSTOM_BUTTON")}*/
                             onMouseDown={() => mouseDown(softButton)}
@@ -81,7 +83,8 @@ class SoftButtonsBody extends React.Component {
             })
         } else if (softButtons.length === 3) {
             items = softButtons.map((softButton, index) => {
-                return (<div className="soft-button-tile-wide th-f-color t-small t-light th-bg-color th-soft-buttons soft-button" style={cssColorStyle}
+                return (<div className={`soft-button-tile-wide th-f-color t-small t-light th-soft-buttons soft-button ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
+                            style={cssColorStyle}
                             key={softButton.softButtonID}
                             /*onClick={() => this.props.onButtonPress(this.props.appID, softButton.softButtonID, "CUSTOM_BUTTON")}*/
                             onMouseDown={() => mouseDown(softButton)}
@@ -97,7 +100,8 @@ class SoftButtonsBody extends React.Component {
             })            
         } else if (softButtons.length === 4) {
             items = softButtons.map((softButton, index) => {
-                return (<div className="soft-button-tile th-f-color t-small t-light th-bg-color th-soft-buttons soft-button" style={cssColorStyle}
+                return (<div className={`soft-button-tile th-f-color t-small t-light th-soft-buttons soft-button ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
+                            style={cssColorStyle}
                             key={softButton.softButtonID}
                             /*onClick={() => this.props.onButtonPress(this.props.appID, softButton.softButtonID, "CUSTOM_BUTTON")}*/
                             onMouseDown={() => mouseDown(softButton)}
@@ -114,7 +118,8 @@ class SoftButtonsBody extends React.Component {
         } else if (softButtons.length === 5) {
             items = softButtons.map((softButton, index) => {
                 if (index === 4) {
-                    return (<div className="soft-button-tile-wide th-f-color t-small t-light th-bg-color th-soft-buttons soft-button" style={cssColorStyle}
+                    return (<div className={`soft-button-tile-wide th-f-color t-small t-light th-soft-buttons soft-button ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
+                                style={cssColorStyle}
                                 key={softButton.softButtonID}
                                 /*onClick={() => this.props.onButtonPress(this.props.appID, softButton.softButtonID, "CUSTOM_BUTTON")}*/
                                 onMouseDown={() => mouseDown(softButton)}
@@ -128,7 +133,8 @@ class SoftButtonsBody extends React.Component {
                                 />) : null}
                         </div>)
                 } else {
-                    return (<div className="soft-button-tile-small th-f-color t-small t-light th-bg-color th-soft-buttons soft-button" style={cssColorStyle}
+                    return (<div className={`soft-button-tile-small th-f-color t-small t-light th-soft-buttons soft-button ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
+                                style={cssColorStyle}
                                 key={softButton.softButtonID}
                                 /*onClick={() => this.props.onButtonPress(this.props.appID, softButton.softButtonID, "CUSTOM_BUTTON")}*/
                                 onMouseDown={() => mouseDown(softButton)}
@@ -145,7 +151,8 @@ class SoftButtonsBody extends React.Component {
             })
         } else if (softButtons.length === 6) {
             items = softButtons.map((softButton, index) => {
-                return (<div className="soft-button-tile-small th-f-color t-small t-light th-bg-color th-soft-buttons soft-button" style={cssColorStyle}
+                return (<div className={`soft-button-tile-small th-f-color t-small t-light th-soft-buttons soft-button ${softButton.isHighlighted ? 'bg-highlighted' : 'th-bg-color'}`}
+                            style={cssColorStyle}
                             key={softButton.softButtonID}
                             /*onClick={() => this.props.onButtonPress(this.props.appID, softButton.softButtonID, "CUSTOM_BUTTON")}*/
                             onMouseDown={() => mouseDown(softButton)}


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/135

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
If a softbutton is highlighted, apply `bg-highlighted` class instead of `th-bg-color`
Softbuttons from Alert, SubtleAlert, ScrollableMessage and Show are affected by this PR (all softButton uses by this HMI)
Softbuttons also exist for some navigation RPCs that are not implemented in this HMI

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
