### PR TITLE
Fix/Server disconnect after failed HMI PTU

### DIFF
--- a/src/js/Controllers/FileSystemController.js
+++ b/src/js/Controllers/FileSystemController.js
@@ -115,9 +115,7 @@ class FileSystemController extends SimpleRPCClient {
     requestPTUFromEndpoint(pts_file_name, url){
       var that = this;
       return new Promise((resolve, reject) => {
-        let ptu_failed_callback = function(){
-          that.disconnect()
-          
+        let ptu_failed_callback = function(){          
           //Return to regular PT flow
           reject()
         };

--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -154,8 +154,11 @@ class WSServer():
       print('\033[1;2mClient %s connected\033[0m' % str(_websocket.remote_address))
       rpc_service = self.service_class(_websocket, _path)
 
-      async for message in _websocket:
-        await rpc_service.on_receive(message)
+      try:
+        async for message in _websocket:
+          await rpc_service.on_receive(message)
+      except websockets.exceptions.ConnectionClosedError as err:
+        print('\033[31;1;2mClient %s unexpected disconnect: "%s"\033[0m' % (str(_websocket.remote_address), str(err)))
 
   class SampleRPCService():
     def __init__(self, _websocket, _path):


### PR DESCRIPTION
Fixes #431 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests

Core branch tested against: develop (https://github.com/smartdevicelink/sdl_core/commit/7912ecb1c083bdaebadd43fe1530e9dded10083a)
Proxy+Test App name tested against: Test Suite

### Summary
- Remove disconnect call in `FileSystemController.js` on failed HMI PTU
- Add error handling for unexpected disconnects in `start_server.py`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
