### PR TITLE
apply default menuLayout at menu open instead of at menu creation

### DIFF
--- a/src/js/InAppList.js
+++ b/src/js/InAppList.js
@@ -16,7 +16,7 @@ export default class InAppMenu extends React.Component {
                     ? "TILES" : "LIST";
             } else {
                 if (app.activeSubMenu) {
-                    layout = SubmenuDeepFind(app.menu, app.activeSubMenu, 0).subMenu.menuLayout;
+                    layout = SubmenuDeepFind(app.menu, app.activeSubMenu, 0).subMenu.menuLayout ?? app.menuLayout;
                 } else {
                     layout = app.menuLayout
                 }

--- a/src/js/reducers.js
+++ b/src/js/reducers.js
@@ -464,7 +464,7 @@ function ui(state = {}, action) {
                 cmdIcon: action.subMenuIcon,
                 secondaryImage: action.secondaryImage,
                 subMenu: [],
-                menuLayout: action.menuLayout ? action.menuLayout : app.menuLayout
+                menuLayout: action.menuLayout
             };
 
             if (menuItem.parentID) {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/434

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
Apply `app.menuLayout` to Sub Menu without specific `menuLayout` when menu is opened instead of when it is created.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
