### PR TITLE
Fix keyboard mask checkbox css

### DIFF
--- a/src/css/components/_keyboard.scss
+++ b/src/css/components/_keyboard.scss
@@ -55,6 +55,7 @@
     color: color(white);
     font-family: monospace;
     overflow-x: scroll;
+    flex-shrink: 0;
 }
 
 .dark-theme .keyboard .input-text input {
@@ -86,6 +87,8 @@
 .dark-theme .keyboard .mask-option-label{
     color: color(white);
     margin-left: 5px;
+    line-height: 1;
+    margin-bottom: 10px;
 }
 
 .light-theme .keyboard .input-text {
@@ -98,6 +101,8 @@
     box-sizing: border-box;
     font-family: monospace;
     overflow-x: scroll;
+    flex-shrink: 0;
+    background-color: color(white);
 }
 
 .light-theme .keyboard .input-text input {
@@ -108,6 +113,7 @@
     border: none;
     box-sizing: border-box;
     display: table;
+    background-color: color(white);
 }
 
 .light-theme .keyboard .input-text .input-autocomplete {
@@ -121,20 +127,26 @@
     align-items: center;
     margin-left: -27px;
     color: #777777;
+    background-color: color(white);
 }
 
 .light-theme .keyboard .mask-option-label {
     margin-left: 5px;
+    line-height: 1;
+    margin-bottom: 10px;
 }
 
 .keyboard .input-row {
     width: 100%;
     white-space: nowrap;
+    display: flex;
+    align-items: end;
 }
 
 .keyboard .mask-checkbox {
     position: relative;
     right: 100px;
+    margin-bottom: 10px;
 }
 
 .numeric .hg-button {

--- a/src/css/components/_keyboard.scss
+++ b/src/css/components/_keyboard.scss
@@ -140,7 +140,7 @@
     width: 100%;
     white-space: nowrap;
     display: flex;
-    align-items: end;
+    align-items: flex-end;
 }
 
 .keyboard .mask-checkbox {


### PR DESCRIPTION
### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
- Set global properties with keyboard user input mask enabled
- Verify placement of checkbox

Core version / branch / commit hash / module tested against: 8.0
Proxy+Test App name / version / branch / commit hash / module tested against: rpcb-js

### Summary
Fixes CSS of the user mask checkbox. It was previously wrapped and non-visible in the parent div.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
