### PR TITLE
Fix/Pause position over timer bounds

### DIFF
--- a/src/js/MediaTrackInfo.js
+++ b/src/js/MediaTrackInfo.js
@@ -45,8 +45,8 @@ export default class MediaTrackInfo extends React.Component {
             if (this.props.countDirection === "COUNTDOWN") {
                 var startPosition = new Date(startDate.getTime() - offset)
                 timeSince = new Date((now - this.props.updateTime) * this.props.countRate)
-                var position = new Date(startPosition - timeSince)
-
+                // Start position is used if paused
+                var position = this.props.paused ? startPosition : new Date(startPosition - timeSince)
                 // Clamp position to timer bounds
                 position = endDate && position < endDate ? endDate : position
                 var endTime = ""
@@ -54,6 +54,8 @@ export default class MediaTrackInfo extends React.Component {
             else {
                 startPosition = new Date(startDate.getTime() + offset)
                 timeSince = new Date(startPosition.getTime() + ((now - this.props.updateTime) * this.props.countRate))
+                // Start position is used if paused
+                position = this.props.paused ? startPosition : new Date(startPosition + timeSince)
                 // Clamp position to timer bounds
                 position = endDate && timeSince > endDate ? endDate : timeSince
 
@@ -64,18 +66,6 @@ export default class MediaTrackInfo extends React.Component {
                 endTime = "/ " + endHours + ":" + endMins + ":" + endSecs
                 if(endHours === "00" && endMins === "00" && endSecs === "00") {
                     endTime = ""
-                }
-            }
-
-            if (this.props.paused) {
-                // Clamp position to timer bounds
-                console.log('[!] Paused', Object.assign({}, this))
-                if(startDate < endDate){ //COUNTUP
-                    position = (endDate && startPosition > endDate) ? endDate : startPosition
-                }
-                else{
-                    position = (endDate && startPosition < endDate) ? endDate : startPosition
-
                 }
             }
 

--- a/src/js/MediaTrackInfo.js
+++ b/src/js/MediaTrackInfo.js
@@ -41,37 +41,31 @@ export default class MediaTrackInfo extends React.Component {
                 break;
         }
         if (startDate) {
-            var timeSince = null;
+            var timeSince = new Date((now - this.props.updateTime) * this.props.countRate);
             if (this.props.countDirection === "COUNTDOWN") {
                 var startPosition = new Date(startDate.getTime() - offset)
-                timeSince = new Date((now - this.props.updateTime) * this.props.countRate)
                 // Start position is used if paused
-                var position = this.props.paused ? startPosition : new Date(startPosition - timeSince)
+                var position = this.props.paused ? startPosition : new Date(startPosition.getTime() - timeSince.getTime())
                 // Clamp position to timer bounds
-                position = endDate && position < endDate ? endDate : position
-                var endTime = ""
+                position = position < endDate ? endDate : position
             }
             else {
                 startPosition = new Date(startDate.getTime() + offset)
-                timeSince = new Date(startPosition.getTime() + ((now - this.props.updateTime) * this.props.countRate))
                 // Start position is used if paused
-                position = this.props.paused ? startPosition : new Date(startPosition + timeSince)
+                position = this.props.paused ? startPosition : new Date(startPosition.getTime() + timeSince.getTime())
                 // Clamp position to timer bounds
-                position = endDate && timeSince > endDate ? endDate : timeSince
+                let isZeroTime = (date) => date.getHours() === 0 && date.getMinutes() === 0 && date.getSeconds() === 0
+                position = !isZeroTime(endDate) && position > endDate ? endDate : position
 
-                // If the numbers are less than 10 put a 0 in front of them
-                var endHours = endDate.getHours() < 10 ? "0" + endDate.getHours() : endDate.getHours()
-                var endMins = endDate.getMinutes() < 10 ? "0" + endDate.getMinutes() : endDate.getMinutes()
-                var endSecs = endDate.getSeconds() < 10 ? "0" + endDate.getSeconds() : endDate.getSeconds()
-                endTime = "/ " + endHours + ":" + endMins + ":" + endSecs
-                if(endHours === "00" && endMins === "00" && endSecs === "00") {
-                    endTime = ""
-                }
+                var endHours = endDate.getHours().toString().padStart(2, '0')
+                var endMins = endDate.getMinutes().toString().padStart(2, '0')
+                var endSecs = endDate.getSeconds().toString().padStart(2, '0')
+                var endTime = !isZeroTime(endDate) ? ("/ " + endHours + ":" + endMins + ":" + endSecs) : ""
             }
 
-            var startHours = position.getHours() < 10 ? "0" + position.getHours() : position.getHours()
-            var startMins = position.getMinutes() < 10 ? "0" + position.getMinutes() : position.getMinutes()
-            var startSecs = position.getSeconds() < 10 ? "0" + position.getSeconds() : position.getSeconds()
+            var startHours = position.getHours().toString().padStart(2, '0')
+            var startMins = position.getMinutes().toString().padStart(2, '0')
+            var startSecs = position.getSeconds().toString().padStart(2, '0')
             var startTime = startHours + ":" + startMins + ":" + startSecs
         } else {
             startTime = null

--- a/src/js/MediaTrackInfo.js
+++ b/src/js/MediaTrackInfo.js
@@ -68,7 +68,15 @@ export default class MediaTrackInfo extends React.Component {
             }
 
             if (this.props.paused) {
-                position = startPosition
+                // Clamp position to timer bounds
+                console.log('[!] Paused', Object.assign({}, this))
+                if(startDate < endDate){ //COUNTUP
+                    position = (endDate && startPosition > endDate) ? endDate : startPosition
+                }
+                else{
+                    position = (endDate && startPosition < endDate) ? endDate : startPosition
+
+                }
             }
 
             var startHours = position.getHours() < 10 ? "0" + position.getHours() : position.getHours()

--- a/src/js/ProgressBar.js
+++ b/src/js/ProgressBar.js
@@ -58,7 +58,7 @@ export default class ProgressBar extends React.Component {
         if (this.props.countDirection === "COUNTDOWN") {
             var startPosition = new Date(startDate.getTime() - offset)
             // Start position is used if paused
-            var position = this.props.paused ? startPosition : new Date(startPosition - timeSince)
+            var position = this.props.paused ? startPosition : new Date(startPosition.getTime() - timeSince.getTime())
             // Clamp position to timer bounds
             position = position < endDate ? endDate : position
             var endPosition = startDate

--- a/src/js/ProgressBar.js
+++ b/src/js/ProgressBar.js
@@ -53,23 +53,23 @@ export default class ProgressBar extends React.Component {
             default:
                 break
         }
+        var timeSince = new Date((now - this.props.updateTime) * this.props.countRate)
 
         if (this.props.countDirection === "COUNTDOWN") {
             var startPosition = new Date(startDate.getTime() - offset)
-            var timeSince = new Date((now - this.props.updateTime) * this.props.countRate)
-            var position = new Date(startPosition  - timeSince)
+            // Start position is used if paused
+            var position = this.props.paused ? startPosition : new Date(startPosition - timeSince)
+            // Clamp position to timer bounds
             position = position < endDate ? endDate : position
             var endPosition = startDate
         }
         else {
             startPosition = new Date(startDate.getTime() + offset)
-            timeSince = new Date(startPosition.getTime() + ((now - this.props.updateTime) * this.props.countRate))
-            position = timeSince > endDate ? endDate : timeSince
+            // Start position is used if paused
+            position = this.props.paused ? startPosition : new Date(startPosition.getTime() + timeSince.getTime())
+            // Clamp position to timer bounds
+            position = position > endDate ? endDate : position
             endPosition = endDate
-        }
-
-        if (this.props.paused) {
-            position = startPosition
         }
 
         let progressStyle = {


### PR DESCRIPTION
Fixes #437 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
- COUNTUP case
  1. Send `SetMediaClockTimer` request with params
  ```
  {
	  "updateMode": "COUNTUP",
	  "startTime": {
		  "hours": 0,
		  "minutes": 0,
		  "seconds": 0
	  },
	  "endTime": {
		  "hours": 0,
		  "minutes": 0,
		  "seconds": 10
	  }
  }
  ```
  2.  Wait for approximately 20 seconds
  3. Send `SetMediaClockTimer` request with `{"updateMode":"PAUSE"}`

- COUNTDOWN case
  1. Send `SetMediaClockTimer` request with params
  ```
  {
	  "updateMode": "COUNTDOWN",
	  "startTime": {
		  "hours": 0,
		  "minutes": 0,
		  "seconds": 10
	  },
	  "endTime": {
		  "hours": 0,
		  "minutes": 0,
		  "seconds": 0
	  }
  }
  ```
  2.  Wait for approximately 20 seconds
  3. Send `SetMediaClockTimer` request with `{"updateMode":"PAUSE"}`

Core branch tested against: release/8.0.0 (https://github.com/smartdevicelink/sdl_core/commit/35f5a0684a36a2a965d5f0e9e784687fa7d82914)
Proxy+Test App name tested against: RPC Builder

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
