### PR TITLE
Fix/App store description overflow CSS

### DIFF
--- a/src/css/components/_alert.scss
+++ b/src/css/components/_alert.scss
@@ -63,7 +63,7 @@
     max-height: calc((#{$master-height} - 75px) * 0.6);
 
     h4 {
-        overflow: scroll;
+        overflow: auto;
     }
 
     img {

--- a/src/css/components/_appstore-menu.scss
+++ b/src/css/components/_appstore-menu.scss
@@ -1,15 +1,12 @@
 .appstore-menu {
     width: 100%;
     height: $master-height - 75px;
-    overflow-y: scroll;
+    overflow-y: hidden;
 
     @include display(flex);
     flex-direction: column;
 }
 
-div::-webkit-scrollbar { 
-    display: none; 
-}
 
 .appstore-menu-item {
     @include display(flex);

--- a/src/css/components/_appstore-menu.scss
+++ b/src/css/components/_appstore-menu.scss
@@ -1,7 +1,7 @@
 .appstore-menu {
     width: 100%;
     height: $master-height - 75px;
-    overflow-y: hidden;
+    overflow-y: scroll;
 
     @include display(flex);
     flex-direction: column;

--- a/src/js/HScrollMenuItem.js
+++ b/src/js/HScrollMenuItem.js
@@ -30,7 +30,7 @@ export default class HScrollMenuItem extends React.Component {
                                                         this.props.interactionId);
         
         if (menuItem.greyOut) {
-            clickHandler = undefined;
+            clickHandler = () => false;
             menuItem.link = undefined;
             buttonClass += " hscrollmenu-item-disabled";
         } else if (menuItem.enabled === false) {


### PR DESCRIPTION
Fixes #440

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Install and uninstall the "Hello Webengine" app

Core version tested against: release/8.0.0 (https://github.com/smartdevicelink/sdl_core/commit/5da57703e02fdf526c300cc26a45ff75f7d1ffd0)

### Summary
- Change `.alert-top h4` overflow value to "auto". The previous value ("scroll") would always display scrollbars, whether or not any content is actually clipped.
- Fix deafult click handler for grayed out app in app store

##### Bug Fixes
Currently clicking an installed(grayed out) app tile in the app store results in a console error
```
Uncaught TypeError: p is not a function
    at onClick (HScrollMenuItem.js:73)
    at onClick (Link.js:37)
    at Object.u (react-dom.production.min.js:14)
    at d (react-dom.production.min.js:14)
    at react-dom.production.min.js:14
    at y (react-dom.production.min.js:15)
    at at (react-dom.production.min.js:52)
    at ot (react-dom.production.min.js:51)
    at ut (react-dom.production.min.js:52)
    at dt (react-dom.production.min.js:56)
```
This PR fixes the default click handler for the `menuItem.greyOut` case

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
