### PR TITLE
Fix/reset timeout for tts.speak

### DIFF
--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -174,8 +174,7 @@ class TTSController {
 
                 this.listener.send(RpcFactory.TTSStartedNotification());
                 this.playNext();
-                if(!rpc.params.speakType.includes('ALERT'))
-                    this.timers[rpc.id] = setInterval(this.onResetTimeout, 9000, rpc.params.appID, "TTS.Speak");
+                this.timers[rpc.id] = setInterval(this.onResetTimeout, 9000, rpc.id, "TTS.Speak");
                 return null;
             case "StopSpeaking":
                 if (this.currentlyPlaying) {

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -174,7 +174,7 @@ class TTSController {
 
                 this.listener.send(RpcFactory.TTSStartedNotification());
                 this.playNext();
-                this.timers[rpc.id] = setInterval(this.onResetTimeout, 9000, rpc.id, "TTS.Speak");
+                this.timers[rpc.id] = setInterval(this.onResetTimeout, 9000, rpc.id);
                 return null;
             case "StopSpeaking":
                 if (this.currentlyPlaying) {

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -374,7 +374,6 @@ class UIController {
                 this.endTimes[rpc.id] = Date.now() + alertTimeout;
                 this.timers[rpc.id] = setTimeout(this.onAlertTimeout, alertTimeout, rpc.id, rpc.params.appID, context ? context : rpc.params.appID, false)
 
-               
                 this.appsWithTimers[rpc.id] = rpc.params.appID
 
                 this.onSystemContext("ALERT", rpc.params.appID)
@@ -708,6 +707,7 @@ class UIController {
             this.listener.send(RpcFactory.OnResetTimeout(msgID,'UI.Alert',1000));
             return;
         }
+
         let imageValidationSuccess = RemoveImageValidationResult(msgID)
 
         store.dispatch(closeAlert(

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -64,7 +64,6 @@ class UIController {
         this.timers = {}
         this.appsWithTimers = {}
         this.endTimes = {}
-        this.onResetTimeoutId = null
     }
     addListener(listener) {
         this.listener = listener
@@ -373,16 +372,8 @@ class UIController {
                 const context = state.activeApp
 
                 this.endTimes[rpc.id] = Date.now() + alertTimeout;
-                this.timers[rpc.id] = setTimeout(
-                    () => {
-                        if (this.endTimes[rpc.id] - Date.now() <= 0) {
-                            ttsController.onResetTimeout(rpc.id)
-                            this.onResetTimeoutId = setInterval(ttsController.onResetTimeout, 10000, rpc.id)
-                        }
-                        this.onAlertTimeout(rpc.id, rpc.params.appID, context ? context : rpc.params.appID, false)
-                    }, 
-                    alertTimeout, 
-                )
+                this.timers[rpc.id] = setTimeout(this.onAlertTimeout, alertTimeout, rpc.id, rpc.params.appID, context ? context : rpc.params.appID, false)
+
                
                 this.appsWithTimers[rpc.id] = rpc.params.appID
 
@@ -717,7 +708,6 @@ class UIController {
             this.listener.send(RpcFactory.OnResetTimeout(msgID,'UI.Alert',1000));
             return;
         }
-        clearInterval(this.onResetTimeoutId)
         let imageValidationSuccess = RemoveImageValidationResult(msgID)
 
         store.dispatch(closeAlert(

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -376,16 +376,12 @@ class UIController {
                 this.timers[rpc.id] = setTimeout(
                     () => {
                         if (this.endTimes[rpc.id] - Date.now() <= 0) {
-                            ttsController.onResetTimeout()
-                            this.onResetTimeoutId = setInterval(ttsController.onResetTimeout, 10000)
+                            ttsController.onResetTimeout(rpc.id)
+                            this.onResetTimeoutId = setInterval(ttsController.onResetTimeout, 10000, rpc.id)
                         }
-                        this.onAlertTimeout()
+                        this.onAlertTimeout(rpc.id, rpc.params.appID, context ? context : rpc.params.appID, false)
                     }, 
                     alertTimeout, 
-                    rpc.id, 
-                    rpc.params.appID, 
-                    context ? context : rpc.params.appID, 
-                    false
                 )
                
                 this.appsWithTimers[rpc.id] = rpc.params.appID


### PR DESCRIPTION
Fixes 
https://github.com/smartdevicelink/generic_hmi/issues/444
https://github.com/smartdevicelink/generic_hmi/issues/442

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
- fix reset timeout for TTS.Speak request during Alert (and SubtleAlert) RPC processing
- requestID in BC.OnResetTimeout for TTS.Speak request during processing Speak RPC

##### Bug Fixes
now HMI sends correct requestID in BC.OnResetTimeout for TTS.Speak request 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
