### PR TITLE
Fix HMI sends redundant TTS.Stopped after TTS.StopSpeaking response #449

### DIFF
--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -9,6 +9,7 @@ class TTSController {
         this.currentlyPlaying = null;
         this.timers = {};
         this.speechSynthesisInterval = null;
+        this.speechPlayer = null;
     }
     addListener(listener) {
         this.listener = listener
@@ -34,13 +35,13 @@ class TTSController {
     }
 
     speak(text) {
-        var speechPlayer = new SpeechSynthesisUtterance();
+        this.speechPlayer = new SpeechSynthesisUtterance();
 
-        speechPlayer.onend = () => {
+        this.speechPlayer.onend = (e) => {
             this.playNext();
         }
 
-        speechPlayer.onerror = (event) => {
+        this.speechPlayer.onerror = (event) => {
             console.warn("TTS error. Make sure your browser supports SpeechSynthesisUtterance");
             this.playNext();
         }
@@ -51,12 +52,12 @@ class TTSController {
         }
 
         this.currentlyPlaying = "TEXT";
-        speechPlayer.text = text;
-        speechPlayer.volume = 1;
-        speechPlayer.rate = 1;
-        speechPlayer.pitch = 0;
+        this.speechPlayer.text = text;
+        this.speechPlayer.volume = 1;
+        this.speechPlayer.rate = 1;
+        this.speechPlayer.pitch = 0;
         window.speechSynthesis.cancel();
-        window.speechSynthesis.speak(speechPlayer);
+        window.speechSynthesis.speak(this.speechPlayer);
 
         // Workaround for chrome issue where long utterances time out
         this.speechSynthesisInterval = setInterval(() => {
@@ -89,6 +90,8 @@ class TTSController {
         this.audioPlayer.onended = null;
         this.audioPlayer.pause();
         this.audioPlayer.src = "";
+        this.speechPlayer.onend = null;
+        this.speechPlayer.onerror = null;
         window.speechSynthesis.pause();
         window.speechSynthesis.cancel();
         this.filePlaylist = [];


### PR DESCRIPTION
Fixes #449

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
[List of tests performed against Core and behaviors verified]

Core version / branch / commit hash / module tested against: [INSERT]
Proxy+Test App name / version / branch / commit hash / module tested against: [INSERT]

### Summary
Added `speechplayer` property to `TTSController` for access it outside the speak method. The reason is that the `speechPlayer` created in `speak` method still exist after `cleanup` method call of `TTSController` and the callback functions such as `onend` or `onerror` still could be called after `cleanup`.  

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
