### PR TITLE
prevent duplicate TTS Stopped notification when Core sends TTS StopSpeaking

### DIFF
--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -127,7 +127,7 @@ class TTSController {
                 this.listener.send(RpcFactory.TTSSpeakSuccess(file.id));
                 return this.playNext();
             }
-        } else {
+        } else if (this.currentlyPlaying) {
             this.speakEnded();
         }
     }


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/449

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Described in issue

### Summary
Do not call `speakEnded` when TTS has been stopped already, such as when TTS Stop Speaking is received

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
