### PR TITLE
Fixed issue: Uncaught TypeError: Cannot read properties of undefined (reading 'pathname') during App activation

### DIFF
--- a/src/js/HScrollMenuItem.js
+++ b/src/js/HScrollMenuItem.js
@@ -68,7 +68,7 @@ export default class HScrollMenuItem extends React.Component {
 
         return (
             <Link
-                to={menuItem.link}
+                to={menuItem.link || '/'}
                 onClick={(e) => (menuItem.enabled === false) ? 
                     e.preventDefault() : clickHandler()}
                 >


### PR DESCRIPTION
Fixes [#457](https://github.com/smartdevicelink/generic_hmi/issues/457)
### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
The problem was that the `Link` object should be initialized with `to` property which couldn't be undefined.
to property sets as `'/'` by default in this fix

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
