### PR TITLE
Adjust TTS Controller to support Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Get an instance of SDL Core running
 
-Note: This requires you to use Ubuntu 16.04 or 18.04.
+Note: This requires you to use Ubuntu 18.04 or 20.04.
 
 Clone the [SDL Core repository](https://github.com/smartdevicelink/sdl_core) and follow the setup instructions for the project. After the project is built, run an instance of SDL Core in your terminal.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ After running the build command, you can launch the Generic HMI in a web browser
 ```
 chromium-browser generic_hmi/build/index.html
 ```
+**NOTE** Chromium is the only supported and tested browser. Browsers built on top of Chromium (Google Chrome) should work but are not officially supported.
 
 ### HMI Backend
 

--- a/src/js/Controllers/TTSController.js
+++ b/src/js/Controllers/TTSController.js
@@ -4,6 +4,7 @@ class TTSController {
         this.addListener = this.addListener.bind(this);
         this.onResetTimeout = this.onResetTimeout.bind(this);
         this.audioPlayer = new Audio();
+        this.audioPlayer.preload = 'none';
         this.filePlaylist = [];
         this.playNext = this.playNext.bind(this);
         this.currentlyPlaying = null;
@@ -57,6 +58,7 @@ class TTSController {
         speechPlayer.pitch = 0;
         window.speechSynthesis.cancel();
         window.speechSynthesis.speak(speechPlayer);
+        if (window.speechSynthesis.paused) window.speechSynthesis.resume();
 
         // Workaround for chrome issue where long utterances time out
         this.speechSynthesisInterval = setInterval(() => {


### PR DESCRIPTION
### Summary
1. Updated versions of Ubuntu required to build Core in README
2. Added bold note that Chromium is the only supported browser to README
3. Fixed TTS issues in Firefox browser
- A warning was printed whenever `audioPlayer.src` was edited because Firefox would try and load audio
- After Speaking once, `window.speechSynthesis` would be stuck paused as in Firefox the `speak` method does not edit the paused property.

Please note that after Speak type FILE in Chrome, that and subsequent Speaks will cause chrome to call `audioPlayer.onerror`. This exists on master as well and does not affect TTS state. I did not look into this as part of this PR.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
