### PR TITLE
Fix/check certificate is already decrypted

### DIFF
--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -338,6 +338,8 @@ class RPCService(WSServer.SampleRPCService):
     private_key = None
     try:
       file_contents = open(crt_file_path, 'rb').read()
+      if b"BEGIN CERTIFICATE" in file_contents:
+        return { 'success': True }
       p12 = crypto.load_pkcs12(base64.b64decode(file_contents),
         Flags.CERT_PASS_PHRASE.encode('utf-8'))
       certificate = p12.get_certificate()


### PR DESCRIPTION
Fixes #464 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

SDL: https://github.com/smartdevicelink/sdl_core/tree/release/8.0.0 (de58a41)
Generic HMI: https://github.com/smartdevicelink/generic_hmi/tree/release/0.11.0 (ec5639b)
SPT: 20210729-Android(1082)
PolicyServer: Version: 2.11.0 https://github.com/smartdevicelink/sdl_server/tree/develop (4a804c6)

### Summary
Added check of the certificate file header, if the `BEGIN CERTIFICATE` string  is exist.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
