### PR TITLE
add flex css to center template images

### DIFF
--- a/src/js/Templates/Shared/Image.js
+++ b/src/js/Templates/Shared/Image.js
@@ -143,7 +143,10 @@ class Image extends React.Component {
                 var hidden = {display:'none'};
                 var size = {
                     height: "100%",
-                    width: "100%"
+                    width: "100%",
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center'
                 }
                 return (
                     <div style={size} ref="canvasContainer">


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/generic_hmi/issues/468

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Described in issue

### Summary
add flex css to center template images

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
