### PR TITLE
Fix keyboard input width

### DIFF
--- a/src/css/components/_keyboard.scss
+++ b/src/css/components/_keyboard.scss
@@ -59,21 +59,18 @@
 }
 
 .dark-theme .keyboard .input-text input {
-    height: 200px;
-    padding: 20px;
-    padding-right: 0px;
+    height: 100%;
     font-size: 36px;
     border: none;
     box-sizing: border-box;
     background-color: color($secondary-color);
     color: color(white);
     display: table;
+    -moz-margin-end: 27px;
 }
 
 .dark-theme .keyboard .input-text .input-autocomplete {
-    height: 200px;
-    padding: 20px;
-    padding-left: 0px;
+    height: 100%;
     font-size: 36px;
     border: none;
     box-sizing: border-box;
@@ -106,20 +103,17 @@
 }
 
 .light-theme .keyboard .input-text input {
-    height: 200px;
-    padding: 20px;
-    padding-right: 0px;
+    height: 100%;
     font-size: 36px;
     border: none;
     box-sizing: border-box;
     display: table;
     background-color: color(white);
+    -moz-margin-end: 27px;
 }
 
 .light-theme .keyboard .input-text .input-autocomplete {
-    height: 200px;
-    padding: 20px;
-    padding-left: 0px;
+    height: 100%;
     font-size: 36px;
     border: none;
     box-sizing: border-box;


### PR DESCRIPTION


Fixes #472 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
PerformInteraction keyboard using:
- Different keyboard layouts
- Autocomplete input list
- Different maskInputCharacters options

Core version / branch / commit hash / module tested against: release/8.0.0
Proxy+Test App name / version / branch / commit hash / module tested against: rpcb-js

### Summary
Adds margin end compensation for firefox broswer. 

Chrome browser has extra space at the end of the text input that could not be removed with CSS. Firefox did not have this extra space, so a margin end of 27px for mozilla was added. This size equals the amount of space that is added by chrome.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
