### PR TITLE
Changed messagecode for ActivateApp for revoked app

### DIFF
--- a/src/js/Controllers/SDLController.js
+++ b/src/js/Controllers/SDLController.js
@@ -202,7 +202,7 @@ class SDLController {
                         return app.appID === activatingApplication;
                     });
                     var revokedAppName = revokedApp ? revokedApp.appName : 'App';
-                    this.getUserFriendlyMessage([ "AppUnsupported" ], (response) => {
+                    this.getUserFriendlyMessage([ "AppUnauthorized" ], (response) => {
                         var heading = 'App is revoked';
                         var body = `${revokedAppName} does not have permission to run`;
                         if (response.result.messages && response.result.messages.length === 1) {


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/sdl_core/issues/2795

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

### Summary
A message with AppUnauthorized code is more obvious for users when the application is revoked.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
