### PR TITLE
Fix/HScrollMenuItem handle undefined link

### DIFF
--- a/src/js/HScrollMenuItem.js
+++ b/src/js/HScrollMenuItem.js
@@ -68,7 +68,7 @@ export default class HScrollMenuItem extends React.Component {
 
         return (
             <Link
-                to={menuItem.link || '/'}
+                to={menuItem.link ?? '#'}
                 onClick={(e) => (menuItem.enabled === false) ? 
                     e.preventDefault() : clickHandler()}
                 >


### PR DESCRIPTION
Fixes #457 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
1. Webengine install
2. Register and activate apps
3. Menu with menuLayout TILES

Core branch tested against: develop (https://github.com/smartdevicelink/sdl_core/commit/31324d58aef55436991fc2bd0a4dce66629146e5)
Proxy+Test App name tested against: Test Suite

### Summary
It looks like the original fix (setting a default value for Link target) was the correct approach but the `"/"` value would redirect the main applications list view.
Currently, for application tiles in the applications list view and for webengine tiles in the appstore view, the launch/confirm actions are handled solely by the `onClick` event handler and the target/to value isn't used to redirect to a different view. It looks like using "#" instead of "/" doesn't cause the same redirect issue

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
