### PR TITLE
Use universal variable for body margin

### DIFF
--- a/src/css/_config.scss
+++ b/src/css/_config.scss
@@ -2,6 +2,8 @@
 $master-width: 960px;
 $master-height: 675px;
 
+$body-margin: 25px;
+
 $primary-color: tire;
 $secondary-color: black;
 

--- a/src/css/base/_base.scss
+++ b/src/css/base/_base.scss
@@ -2,7 +2,7 @@ body {
     font-family: 'LivioNorm', Helvetica, sans-serif;
     font-weight: normal;
     font-size: 15px;
-    margin: 25px;
+    margin: $body-margin;
     overflow: hidden;
 }
 

--- a/src/css/components/_alert.scss
+++ b/src/css/components/_alert.scss
@@ -7,7 +7,7 @@
     background-color   : rgba(0, 0, 0, 0.75);
     width: $master-width;
     height: $master-height;
-    margin: 25px;
+    margin: $body-margin;
     z-index: 1001;
 }
 

--- a/src/css/components/_app-services-nav.scss
+++ b/src/css/components/_app-services-nav.scss
@@ -177,7 +177,7 @@
   left              : 0;
   right             : 0;
   width: $master-width;
-  margin: 25px 0px 0px 25px;  
+  margin: $body-margin 0px 0px $body-margin;  
   z-index:1001;
 }
 

--- a/src/css/components/_scrollable_message.scss
+++ b/src/css/components/_scrollable_message.scss
@@ -7,7 +7,7 @@
     background-color   : rgba(0, 0, 0, 0.75);
     width: $master-width;
     height: $master-height;
-    margin: 25px;
+    margin: $body-margin;
     z-index:1001;
 }
 

--- a/src/css/components/_slider.scss
+++ b/src/css/components/_slider.scss
@@ -7,7 +7,7 @@
     background-color   : rgba(0, 0, 0, 0.75);
     width: $master-width;
     height: $master-height;
-    margin: 25px;
+    margin: $body-margin;
     z-index:1001;
 }
 

--- a/src/css/components/_subtle-alert.scss
+++ b/src/css/components/_subtle-alert.scss
@@ -7,7 +7,7 @@
     background-color   : rgba(0, 0, 0, 0);
     width: $master-width;
     height: $master-height;
-    margin: 25px;
+    margin: $body-margin;
     z-index:1001;
 }
 


### PR DESCRIPTION
Fixes #489 

### Testing Plan
- Edit `$body-margin` and verify all overlays (Alert, ScrollableMessage, etc.) keep the same margin as the main body

#### Core Tests
Tested with `$body-margin: 0px` and verified that margin was removed from all overlays

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: SDL Test Suite

### Summary
Store body margin in universal variable for easy modification

### Changelog
##### Bug Fixes
* Ensure that body margin stay the same for all overlays

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
