### PR TITLE
IP address local storage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,15 @@ class HMIApp extends React.Component {
         this.onTouchMove = this.onTouchMove.bind(this);
         this.onTouchEnd = this.onTouchEnd.bind(this);
         this.onTouchEvent = this.onTouchEvent.bind(this);
+
+        var FileSystemApiUrl = localStorage.getItem("FileSystemApiUrl")
+        var AppStoreDirectoryUrl = localStorage.getItem("AppStoreDirectoryUrl")
+        var ptuUrlOverride = localStorage.getItem("ptuUrlOverride")
+        if (FileSystemApiUrl && AppStoreDirectoryUrl && ptuUrlOverride) {
+            window.flags.FileSystemApiUrl = FileSystemApiUrl;
+            window.flags.AppStoreDirectoryUrl = AppStoreDirectoryUrl;
+            window.flags.ptuUrlOverride = ptuUrlOverride;
+        }
     }
     handleClick() {
         var theme = !this.state.dark

--- a/src/js/AppHeader.js
+++ b/src/js/AppHeader.js
@@ -42,6 +42,9 @@ class BackendConnectionStatus extends React.Component {
             const ip = url.substring(url.indexOf('://') + 3, url.indexOf(':', 5));
             window.flags.AppStoreDirectoryUrl = `http://${ip}:8080/app-directory.json`;
             window.flags.ptuUrlOverride = `http://${ip}:3001/api/v1/staging/policy`;
+            localStorage.setItem("FileSystemApiUrl", window.flags.FileSystemApiUrl);
+            localStorage.setItem("AppStoreDirectoryUrl", window.flags.AppStoreDirectoryUrl);
+            localStorage.setItem("ptuUrlOverride", window.flags.ptuUrlOverride);
             FileSystemController.connect(window.flags.FileSystemApiUrl).then(() => {
                 console.log('Connected to FileSystemController');
                 FileSystemController.updateAppStoreConnection(true);


### PR DESCRIPTION
For CES 2022 Demo

### Summary
Saves ip address configured in the settings menu to be saved to localStorage. After ip is saved to local storage, the browser will load the same IP on future window sessions.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
