### PR TITLE
Remove UI.SetDisplayLayout implementation

### DIFF
--- a/src/js/Controllers/RpcFactory.js
+++ b/src/js/Controllers/RpcFactory.js
@@ -818,47 +818,7 @@ class RpcFactory {
         }
         return msg  
     }
-    static SetDisplayLayoutResponse(rpc, disallowedLayout=false) {
-        var layout = rpc.params.displayLayout;
-        var supportedTemplates = [ ...capabilities["MEDIA"].displayCapabilities.templatesAvailable, 'MEDIA'];
-        if (!disallowedLayout && supportedTemplates.includes(layout)) {
-            if (layout === "DEFAULT") {
-                layout = "MEDIA"
-            }
-            var response = {
-                "jsonrpc": "2.0",
-                "id": rpc.id,
-                "result": {
-                    "method": rpc.method,
-                    "code": 0
-                }
-            }
-            if (capabilities[layout].displayCapabilities) {
-                response.result["displayCapabilities"] = capabilities[layout].displayCapabilities
-            }
-            if (capabilities[layout].softButtonCapabilities) {
-                response.result["softButtonCapabilities"] = capabilities[layout].softButtonCapabilities
-            }
-            if (capabilities[layout].buttonCapabilities) {
-                response.result["buttonCapabilities"] = capabilities[layout].buttonCapabilities
-            }
-            return (response)        
-        } else {
-            return ({
-                "jsonrpc": "2.0",
-                "id": rpc.id,
-                "error": {
-                    "code": 1,
-                    "message": disallowedLayout ? 'Only MEDIA apps may use the MEDIA template'
-                        : "The requested layout is not supported on this HMI",
-                    "data": {
-                        "method": rpc.method
-                    }
-                }
-            })            
-        }
 
-    }
     static UICancelInteractionIgnoredResponse(rpc) {
         return ({
             "jsonrpc": "2.0",

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -265,26 +265,6 @@ class UIController {
                     rpc.params.countRate
                 ))
                 return true
-            case "SetDisplayLayout":
-                console.log("Warning: RPC SetDisplayLayout is deprecated");
-                const prevDisplayLayout = appUIState ? appUIState.displayLayout : "";
-                var setDisplayLayoutApp = store.getState().appList.find((app) => {
-                    return app.appID === rpc.params.appID;
-                });
-
-                var disallowedLayout = rpc.params.displayLayout === 'MEDIA' && !setDisplayLayoutApp.isMediaApplication;
-                if (disallowedLayout) {
-                    rpc.params.displayLayout = prevDisplayLayout;
-                }
-                if (rpc.params.displayLayout === 'DEFAULT') {
-                    rpc.params.displayLayout = getDefaultLayout(setDisplayLayoutApp)
-                }
-                store.dispatch(setTemplateConfiguration(rpc.params.displayLayout, rpc.params.appID, rpc.params.dayColorScheme, rpc.params.nightColorScheme));
-
-                if (prevDisplayLayout !== appUIState.displayLayout) {
-                    this.listener.send(RpcFactory.OnSystemCapabilityDisplay(rpc.params.displayLayout, rpc.params.appID));
-                }
-                return {"rpc": RpcFactory.SetDisplayLayoutResponse(rpc, disallowedLayout)};
             case "SetGlobalProperties":
                 store.dispatch(setGlobalProperties(
                     rpc.params.appID,


### PR DESCRIPTION
Since the `UI.SetDisplayLayout` RPC was removed from the HMI_API.xml in the core implementation of https://github.com/smartdevicelink/sdl_core/issues/3706, the RPC should also be removed from the Generic HMI

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
- Send `SetDisplayLayout` RPC from SDL app. The HMI should recieve an equivalent `UI.Show` request rather than a `UI.SetDisplayLayout` request

Core version tested against: develop
Proxy+Test App name tested against: RPC Builder

### Summary
Removes the implementation of the UI.SetDisplayLayout RPC

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
