### PR TITLE
Remove app store directory url local storage loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,8 +77,6 @@ class HMIApp extends React.Component {
 
         let FileSystemApiUrl = localStorage.getItem("FileSystemApiUrl");
         if (FileSystemApiUrl) { window.flags.FileSystemApiUrl = FileSystemApiUrl; }
-        let AppStoreDirectoryUrl = localStorage.getItem("AppStoreDirectoryUrl");
-        if (AppStoreDirectoryUrl) { window.flags.AppStoreDirectoryUrl = AppStoreDirectoryUrl; }
     }
     handleClick() {
         var theme = !this.state.dark


### PR DESCRIPTION
### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Load generic hmi and check app store is functioning.

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: none needed

### Summary
Removes unnecessary loading of the app store directory url from local storage since this property is never set.

### Tasks Remaining:
- [x] [Task 1]
- [x] [Task 2]

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
