### PR TITLE
Fix HMI PTU process when using symlinks with Generic HMI

### DIFF
--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -260,7 +260,7 @@ class RPCService(WSServer.SampleRPCService):
 
     # Validate file path
     def isFileNameValid(_file_name):
-      path = os.path.abspath(os.path.normpath(_file_name))
+      path = os.path.realpath(os.path.normpath(_file_name))
       if os.path.commonpath([path, os.getcwd()]) != os.getcwd(): # Trying to save outside the working directory
         return False
       return True


### PR DESCRIPTION

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Test HMI PTU when running the backend server from a symlinked directory (`ln -s path/to/generic_hmi && cd ./generic_hmi && bash deploy_server.sh`)

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: RPC builder app JS (master)

### Summary
Changes directory check in backend server from `abspath` to `realpath` so that it works with symlinks

### Changelog
##### Bug Fixes
* Fix check in HMI PTU logic to work with symlinks

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
