### PR TITLE
0.12.0 css fixes

### DIFF
--- a/src/css/components/_alert.scss
+++ b/src/css/components/_alert.scss
@@ -61,6 +61,7 @@
     display: flex;
     padding: 30px;
     max-height: calc((#{$master-height} - 75px) * 0.6);
+    justify-content: space-around;
 
     h4 {
         overflow: auto;

--- a/src/css/components/_h-scroll-menu-item.scss
+++ b/src/css/components/_h-scroll-menu-item.scss
@@ -13,7 +13,7 @@
         align-items: center;
         justify-content: center;
         @include size(50%);
-        margin: 16% auto 12px;
+        margin: 13% auto 12px;
 
         border-radius: 4px;
 
@@ -40,7 +40,7 @@
         scrollbar-width: none;
         bottom: 0px;
         width: 100%;
-        height: 23%;
+        height: 33%;
         display: flex;
         flex-direction: column;
         justify-content: center;
@@ -86,6 +86,7 @@
         bottom: -2px;
         width: 50px;
         max-height: 100%;
+        max-width: 60px;
         object-fit: contain;
     }
 }

--- a/src/css/components/_h-scroll-menu-item.scss
+++ b/src/css/components/_h-scroll-menu-item.scss
@@ -37,6 +37,9 @@
     &__name {
         position: absolute;
         overflow: scroll;
+       p {
+            overflow: hidden;
+        }
         scrollbar-width: none;
         bottom: 0px;
         width: 100%;

--- a/src/css/components/_keyboard.scss
+++ b/src/css/components/_keyboard.scss
@@ -16,7 +16,8 @@
     padding-top: 10px;
     height: 40%;
     display: flex;
-    justify-content: space-between;
+    transform: translateX(-20px);
+    width: 101%;
    .hscrollmenu-item__name {
         overflow: hidden;
         bottom: 5px;
@@ -25,7 +26,6 @@
 
 .keyboard .hscrollmenu-block {
     height: 98%;
-    margin-left: 0px;
 }
 
 .keyboard .with-search {

--- a/src/css/components/_non-media.scss
+++ b/src/css/components/_non-media.scss
@@ -57,6 +57,7 @@
 .non-media-graphic {
     @include display(flex);
     @include align-items(center);
+    @include justify-content(center);
     margin: auto 50px; 
     @include size(calc((#{$master-height} - 173px) / 1.22439 ));
     img {

--- a/src/css/components/_v-scroll-menu-item.scss
+++ b/src/css/components/_v-scroll-menu-item.scss
@@ -19,7 +19,7 @@
     }
 
     &__image {
-        padding: 1% 1%;
+        padding: 2%;
         flex: 0.75;
         align-self: flex-start;
         border-radius: 4px;
@@ -34,6 +34,7 @@
             margin:auto;
             max-width: 100%;
             max-height: 100%;
+            object-fit: contain;
         }
 
         div {
@@ -42,6 +43,7 @@
             display: flex;
             flex-direction: column;
             align-items: center;
+            padding: 10px;
 
             canvas {
                 margin:auto;

--- a/src/js/Keyboard.js
+++ b/src/js/Keyboard.js
@@ -322,6 +322,7 @@ class Keyboard extends Component {
                 <div 
                   className="auto-complete-list" 
                   ref={r => (this.scrollRef = r)}
+                  style={autoCompleteList.length === 0 ? {"display" : "none"} : {}}
                   onMouseDown={this.onMouseDown}
                   onMouseUp={this.onMouseUp}
                   onMouseMove={this.onMouseMove}


### PR DESCRIPTION
### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
See summary. Test hscroll, vscroll, keyboard, keyboard with search, and app store for css updates.

Core version / branch / commit hash / module tested against: 8.1
Proxy+Test App name / version / branch / commit hash / module tested against: rpcb-js

### Summary
- Fix non media graphic to be centered
- Hide autocomplete list if there are no autocomplete items present
- Set max width for a secondary image used in a tile/icon layout for perform interaction and keyboard with search
- Give padding to choice set list images to avoid squishing them
- Fix ICON_WITH_SEARCH spacing when there are 2 items.
- Allow App store and app list to have an app name that requires 2 lines (adjust image accordingly).
- Fix app store text and icon alignment when the description is short

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
