### PR TITLE
Fix main graphic on templates

### DIFF
--- a/src/css/components/_graphic-with-text-and-softbuttons.scss
+++ b/src/css/components/_graphic-with-text-and-softbuttons.scss
@@ -9,6 +9,7 @@
         padding-left: 10px;
         max-height: 100%;
         width: 100%;
+        max-width: 100%;
         object-fit: contain;
     }
 

--- a/src/css/components/_graphic-with-text-buttons.scss
+++ b/src/css/components/_graphic-with-text-buttons.scss
@@ -7,7 +7,7 @@
 
 .graphic-with-text-buttons-container {
     height: 100%;
-    width: 50%;
+    width: 100%;
     display: flex;
     align-items: center;
 }
@@ -19,6 +19,7 @@
     max-height:100%;
     object-fit: contain;
     margin-bottom: 20px;
+    max-width: 100%;
 }
 
  .graphic-with-text-buttons-template .soft-buttons {

--- a/src/css/components/_graphic-with-text.scss
+++ b/src/css/components/_graphic-with-text.scss
@@ -18,6 +18,7 @@
     max-height: 100%;
     width: 100%;
     object-fit: contain;
+    max-width: 100%;
 }
 
 .graphic-with-text-template .text-body {

--- a/src/css/components/_graphic-with-tiles.scss
+++ b/src/css/components/_graphic-with-tiles.scss
@@ -7,7 +7,7 @@
 
 .graphic-with-tiles-container {
     height: 100%;
-    width: 50%;
+    width: 100%;
     display: flex;
     align-items: center;
 }
@@ -19,17 +19,18 @@
     max-height:100%;
     object-fit: contain;
     margin-bottom: 20px;
+    max-width: 100%;
 }
 
 .graphic-with-tiles-template .soft-buttons {
     width: 100%;
     height: 100%;
     @include display(flex);
-    @include justify-content(flex-start);
+    @include justify-content(center);
     @include flex-direction(row);
     @include flex-wrap(wrap);
     @include align-items(stretch);
-    @include align-content(flex-start);
+    @include align-content(center);
     //@include align-content(space-between);
     padding-left: 10px;
     padding-right: 25px;

--- a/src/css/components/_large-graphic-only.scss
+++ b/src/css/components/_large-graphic-only.scss
@@ -7,6 +7,9 @@
     width: 100%;
     height: calc(#{$master-height} - 75px);
     padding: 25px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .large-graphic-only .large-graphic {

--- a/src/css/components/_large-graphic-with-softbuttons.scss
+++ b/src/css/components/_large-graphic-with-softbuttons.scss
@@ -11,6 +11,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .large-graphic-with-softbuttons-bottom-container{
@@ -27,6 +28,7 @@
     object-fit: contain;
     margin-bottom: 50px;
     height: 100%;
+    max-width: 100%;
 }
 
 .large-graphic-with-softbuttons-template svg {
@@ -49,6 +51,7 @@
     margin-bottom: 0px !important;
     margin-right: 20px;
     min-width: 0;
+    height: 100%;
 }
 
 .large-graphic-with-softbuttons-template .soft-button p {
@@ -60,4 +63,13 @@
 
 .large-graphic-with-softbuttons-template .soft-button:last-child {
     margin-right: 0px !important;
+}
+
+.large-graphic-with-softbuttons-template .soft-button-image {
+    @include size(50px);
+}
+
+.large-graphic-with-softbuttons-template .soft-button-image-static {
+    max-height: 50px;
+    min-width: 50px;
 }

--- a/src/css/components/_text-buttons-with-graphic.scss
+++ b/src/css/components/_text-buttons-with-graphic.scss
@@ -7,7 +7,7 @@
 
 .text-buttons-with-graphic-container {
     height: 100%;
-    width: 50%;
+    width: 100%;
     display: flex;
     align-items: center;
 }
@@ -19,6 +19,7 @@
     max-height:100%;
     object-fit: contain;
     margin-bottom: 20px;
+    max-width: 100%;
 }
 
  .text-buttons-with-graphic-template .soft-buttons {

--- a/src/css/components/_text-with-graphic.scss
+++ b/src/css/components/_text-with-graphic.scss
@@ -7,7 +7,7 @@
 
 .text-with-graphic-container {
     height: 100%;
-    width: 50%;
+    width: 100%;
     display: flex;
     align-items: center;
 }
@@ -18,6 +18,7 @@
     width: 100%;
     max-height:100%;
     object-fit: contain;
+    max-width: 100%;
 }
 
 .text-with-graphic-template .text-body {

--- a/src/css/components/_tiles-with-graphic.scss
+++ b/src/css/components/_tiles-with-graphic.scss
@@ -7,7 +7,7 @@
 
 .tiles-with-graphic-container {
     height: 100%;
-    width: 50%;
+    width: 100%;
     display: flex;
     align-items: center;
 }
@@ -19,17 +19,18 @@
     max-height:100%;
     object-fit: contain;
     margin-bottom: 20px;
+    max-width: 100%;
 }
 
 .tiles-with-graphic-template .soft-buttons {
     width: 100%;
     height: 100%;
     @include display(flex);
-    @include justify-content(flex-start);
+    @include justify-content(center);
     @include flex-direction(row);
     @include flex-wrap(wrap);
     @include align-items(stretch);
-    @include align-content(flex-start);
+    @include align-content(center);
     //@include align-content(space-between);
     padding-right: 10px;
     padding-left: 25px;

--- a/src/js/Templates/GraphicWithTextButtons/GraphicWithTextButtons.js
+++ b/src/js/Templates/GraphicWithTextButtons/GraphicWithTextButtons.js
@@ -38,7 +38,9 @@ class GraphicWithTextButtons extends React.Component {
             <div>
                 <AppHeader backLink="/" menuName="Apps"/>
                 <div className="graphic-with-text-buttons-template" style={this.getColorScheme()}>
-                    <LargeGraphic class="graphic-with-text-buttons-container"/>
+                    <div className="min-width-50">
+                        <LargeGraphic class="graphic-with-text-buttons-container"/>
+                    </div>
                     <SoftButtons class="graphic-with-text-buttons-container"/>
                 </div>
             </div>

--- a/src/js/Templates/GraphicWithTiles/GraphicWithTiles.js
+++ b/src/js/Templates/GraphicWithTiles/GraphicWithTiles.js
@@ -38,7 +38,9 @@ class GraphicWithTiles extends React.Component {
             <div>
                 <AppHeader backLink="/" menuName="Apps"/>
                 <div className="graphic-with-tiles-template" style={this.getColorScheme()}>
-                    <LargeGraphic class="graphic-with-tiles-container"/>
+                    <div className="min-width-50">
+                        <LargeGraphic class="graphic-with-tiles-container"/>
+                    </div>
                     <SoftButtons class="graphic-with-tiles-container"/>
                 </div>
             </div>

--- a/src/js/Templates/TextButtonsWithGraphic/TextButtonsWithGraphic.js
+++ b/src/js/Templates/TextButtonsWithGraphic/TextButtonsWithGraphic.js
@@ -39,7 +39,9 @@ class TextButtonswithGraphic extends React.Component {
                 <AppHeader backLink="/" menuName="Apps"/>
                 <div className="text-buttons-with-graphic-template" style={this.getColorScheme()}>
                     <SoftButtons class="text-buttons-with-graphic-container"/>
-                    <LargeGraphic class="text-buttons-with-graphic-container"/>
+                    <div className="min-width-50">
+                        <LargeGraphic class="text-buttons-with-graphic-container"/>
+                    </div>                    
                 </div>
             </div>
         )

--- a/src/js/Templates/TextWithGraphic/TextWithGraphic.js
+++ b/src/js/Templates/TextWithGraphic/TextWithGraphic.js
@@ -40,7 +40,9 @@ class TextWithGraphic extends React.Component {
                     <div className="text-with-graphic-container">
                         <TextFields/>
                     </div>
-                    <LargeGraphic class="text-with-graphic-container"/>
+                    <div className="min-width-50">
+                        <LargeGraphic class="text-with-graphic-container"/>
+                    </div>
                 </div>
             </div>
         )

--- a/src/js/Templates/TilesWithGraphic/TilesWithGraphic.js
+++ b/src/js/Templates/TilesWithGraphic/TilesWithGraphic.js
@@ -39,7 +39,9 @@ class TilesWithGraphic extends React.Component {
                 <AppHeader backLink="/" menuName="Apps"/>
                 <div className="tiles-with-graphic-template" style={this.getColorScheme()}>
                     <SoftButtons class="tiles-with-graphic-container"/>
-                    <LargeGraphic class="tiles-with-graphic-container"/>
+                    <div className="min-width-50">
+                        <LargeGraphic class="tiles-with-graphic-container"/>
+                    </div>
                 </div>
             </div>
         )


### PR DESCRIPTION
### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
- Send a fully populated show that includes graphics, text, and a mix of text buttons and buttons with images.
- Cycle through all of the supported template and ensure that the graphic is contained within its appropriate space.

Core version / branch / commit hash / module tested against: 8.1
Proxy+Test App name / version / branch / commit hash / module tested against: rpcb-js

### Summary
Adds a containing div to the large graphic component to fix an issue where the image was exceeding the max width size.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
