### PR TITLE
Fix large graphic sizing

### DIFF
--- a/src/css/components/_double-graphic-with-softbuttons.scss
+++ b/src/css/components/_double-graphic-with-softbuttons.scss
@@ -24,9 +24,10 @@
 .double-graphic-with-softbuttons-template .double-graphic {
     padding-right: 10px;
     padding-left: 10px;
-    width:50%;
+    width:100%;
     height:100%;
     max-height: 100%;
+    max-width: 100%;
     object-fit: contain;
 }
 

--- a/src/css/components/_double-graphic-with-softbuttons.scss
+++ b/src/css/components/_double-graphic-with-softbuttons.scss
@@ -22,13 +22,12 @@
 }
 
 .double-graphic-with-softbuttons-template .double-graphic {
-    padding-right: 10px;
-    padding-left: 10px;
     width:100%;
     height:100%;
     max-height: 100%;
     max-width: 100%;
     object-fit: contain;
+    display: flex;
 }
 
  .double-graphic-with-softbuttons-template .soft-buttons {
@@ -69,4 +68,14 @@
 
 .width-50 {
     width:50%;
+}
+
+.height-100 {
+    height:100%;
+}
+
+.double-graphic-with-softbuttons-template .double-graphic-container {
+    width:50%;
+    height:100%;
+    display: flex;
 }

--- a/src/css/components/_double-graphic-with-softbuttons.scss
+++ b/src/css/components/_double-graphic-with-softbuttons.scss
@@ -26,6 +26,7 @@
     padding-left: 10px;
     width:50%;
     height:100%;
+    max-height: 100%;
     object-fit: contain;
 }
 

--- a/src/css/components/_double-graphic-with-softbuttons.scss
+++ b/src/css/components/_double-graphic-with-softbuttons.scss
@@ -66,3 +66,7 @@
 .double-graphic-with-softbuttons-template .soft-button:last-child {
     margin-right: 0px !important;
 }
+
+.width-50 {
+    width:50%;
+}

--- a/src/css/components/_double-graphic-with-softbuttons.scss
+++ b/src/css/components/_double-graphic-with-softbuttons.scss
@@ -78,4 +78,6 @@
     width:50%;
     height:100%;
     display: flex;
+    justify-content: center;
+    align-items: center;
 }

--- a/src/css/components/_graphic-with-text-and-softbuttons.scss
+++ b/src/css/components/_graphic-with-text-and-softbuttons.scss
@@ -5,8 +5,6 @@
     display: flex;
 
     .large-graphic {
-        padding-right: 25px;
-        padding-left: 10px;
         max-height: 100%;
         width: 100%;
         max-width: 100%;

--- a/src/css/components/_graphic-with-text-buttons.scss
+++ b/src/css/components/_graphic-with-text-buttons.scss
@@ -10,6 +10,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .graphic-with-text-buttons-template .large-graphic {

--- a/src/css/components/_graphic-with-text-buttons.scss
+++ b/src/css/components/_graphic-with-text-buttons.scss
@@ -14,8 +14,6 @@
 }
 
 .graphic-with-text-buttons-template .large-graphic {
-    padding-left: 25px;
-    padding-right: 10px;
     width:100%;
     max-height:100%;
     object-fit: contain;

--- a/src/css/components/_graphic-with-text.scss
+++ b/src/css/components/_graphic-with-text.scss
@@ -14,8 +14,6 @@
 }
 
 .graphic-with-text-template .large-graphic {
-    padding-right: 25px;
-    padding-left: 10px;
     max-height: 100%;
     width: 100%;
     object-fit: contain;

--- a/src/css/components/_graphic-with-text.scss
+++ b/src/css/components/_graphic-with-text.scss
@@ -10,6 +10,7 @@
     min-width: 50%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .graphic-with-text-template .large-graphic {

--- a/src/css/components/_graphic-with-tiles.scss
+++ b/src/css/components/_graphic-with-tiles.scss
@@ -14,8 +14,6 @@
 }
 
 .graphic-with-tiles-template .large-graphic {
-    padding-left: 25px;
-    padding-right: 10px;
     width:100%;
     max-height:100%;
     object-fit: contain;

--- a/src/css/components/_graphic-with-tiles.scss
+++ b/src/css/components/_graphic-with-tiles.scss
@@ -10,6 +10,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .graphic-with-tiles-template .large-graphic {

--- a/src/css/components/_large-graphic-only.scss
+++ b/src/css/components/_large-graphic-only.scss
@@ -15,6 +15,8 @@
 .large-graphic-only .large-graphic {
     width:100%;
     height:100%;
+    max-height: 100%;
+    max-width: 100%;
     object-fit: contain;
 
 }

--- a/src/css/components/_large-graphic-with-softbuttons.scss
+++ b/src/css/components/_large-graphic-with-softbuttons.scss
@@ -30,6 +30,8 @@
     height: 100%;
     max-width: 100%;
     max-height: 100%;
+    display:flex;
+    justify-content: center;
 }
 
 .large-graphic-with-softbuttons-template svg {

--- a/src/css/components/_large-graphic-with-softbuttons.scss
+++ b/src/css/components/_large-graphic-with-softbuttons.scss
@@ -29,6 +29,7 @@
     margin-bottom: 50px;
     height: 100%;
     max-width: 100%;
+    max-height: 100%;
 }
 
 .large-graphic-with-softbuttons-template svg {

--- a/src/css/components/_on-screen-presets.scss
+++ b/src/css/components/_on-screen-presets.scss
@@ -8,6 +8,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .on-screen-presets .soft-buttons {

--- a/src/css/components/_text-buttons-only.scss
+++ b/src/css/components/_text-buttons-only.scss
@@ -10,6 +10,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .text-buttons-only-template .soft-buttons {

--- a/src/css/components/_text-buttons-with-graphic.scss
+++ b/src/css/components/_text-buttons-with-graphic.scss
@@ -14,8 +14,6 @@
 }
 
 .text-buttons-with-graphic-template .large-graphic {
-    padding-right: 25px;
-    padding-left: 10px;
     width:100%;
     max-height:100%;
     object-fit: contain;

--- a/src/css/components/_text-buttons-with-graphic.scss
+++ b/src/css/components/_text-buttons-with-graphic.scss
@@ -10,6 +10,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .text-buttons-with-graphic-template .large-graphic {

--- a/src/css/components/_text-with-graphic.scss
+++ b/src/css/components/_text-with-graphic.scss
@@ -14,8 +14,6 @@
 }
 
 .text-with-graphic-template .large-graphic {
-    padding-right: 25px;
-    padding-left: 10px;
     width: 100%;
     max-height:100%;
     object-fit: contain;

--- a/src/css/components/_text-with-graphic.scss
+++ b/src/css/components/_text-with-graphic.scss
@@ -10,6 +10,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .text-with-graphic-template .large-graphic {

--- a/src/css/components/_tiles-only.scss
+++ b/src/css/components/_tiles-only.scss
@@ -10,6 +10,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .tiles-only-template .soft-buttons {

--- a/src/css/components/_tiles-with-graphic.scss
+++ b/src/css/components/_tiles-with-graphic.scss
@@ -10,6 +10,7 @@
     width: 100%;
     display: flex;
     align-items: center;
+    justify-content: center;
 }
 
 .tiles-with-graphic-template .large-graphic {

--- a/src/css/components/_tiles-with-graphic.scss
+++ b/src/css/components/_tiles-with-graphic.scss
@@ -14,8 +14,6 @@
 }
 
 .tiles-with-graphic-template .large-graphic {
-    padding-right: 25px;
-    padding-left: 10px;
     width:100%;
     max-height:100%;
     object-fit: contain;

--- a/src/js/Templates/DoubleGraphicWithSoftbuttons/DoubleGraphicBody.js
+++ b/src/js/Templates/DoubleGraphicWithSoftbuttons/DoubleGraphicBody.js
@@ -46,8 +46,12 @@ export default class DoubleGraphicBody extends React.Component {
     render() {
         return (
             <div className={this.props.class}>            
+                <div className="min-width-50">
                     {this.primaryGraphic()}
+                </div>
+                <div className="min-width-50">
                     {this.secondaryGraphic()}
+                </div>
             </div>
         )
     }

--- a/src/js/Templates/DoubleGraphicWithSoftbuttons/DoubleGraphicBody.js
+++ b/src/js/Templates/DoubleGraphicWithSoftbuttons/DoubleGraphicBody.js
@@ -15,14 +15,20 @@ export default class DoubleGraphicBody extends React.Component {
 
     primaryGraphic() {
         if(this.props.graphic) {
+            var image;
             if(this.props.graphic.imageType === "STATIC") {
-                return <StaticIcon class="double-graphic" image={this.props.graphic.value} />
+                image = <StaticIcon class="double-graphic" image={this.props.graphic.value} />
             } else {
-                return <Image class="double-graphic" 
+                image = <Image class="double-graphic" 
                     image={this.props.graphic.value} 
                     isTemplate={this.props.graphic.isTemplate}
                     fillColor={this.fillColor()}/>
             }
+            return (
+                <div className="min-width-50 width-50">
+                    { image }
+                </div>
+            );
         } else {
             return null
         }
@@ -45,13 +51,9 @@ export default class DoubleGraphicBody extends React.Component {
 
     render() {
         return (
-            <div className={this.props.class}>            
-                <div className="min-width-50">
-                    {this.primaryGraphic()}
-                </div>
-                <div className="min-width-50">
-                    {this.secondaryGraphic()}
-                </div>
+            <div className={this.props.class}>
+                {this.primaryGraphic()}
+                {this.secondaryGraphic()}
             </div>
         )
     }

--- a/src/js/Templates/DoubleGraphicWithSoftbuttons/DoubleGraphicBody.js
+++ b/src/js/Templates/DoubleGraphicWithSoftbuttons/DoubleGraphicBody.js
@@ -25,7 +25,7 @@ export default class DoubleGraphicBody extends React.Component {
                     fillColor={this.fillColor()}/>
             }
             return (
-                <div className="min-width-50 width-50">
+                <div className="double-graphic-container">
                     { image }
                 </div>
             );
@@ -36,14 +36,20 @@ export default class DoubleGraphicBody extends React.Component {
 
     secondaryGraphic() {
         if(this.props.secondaryGraphic) {
+            var image;
             if(this.props.secondaryGraphic.imageType === "STATIC") {
-                return <StaticIcon class="double-graphic" image={this.props.secondaryGraphic.value} />
+                image = <StaticIcon class="double-graphic" image={this.props.secondaryGraphic.value} />
             } else {
-                return <Image class="double-graphic" 
+                image = <Image class="double-graphic" 
                     image={this.props.secondaryGraphic.value} 
                     isTemplate={this.props.secondaryGraphic.isTemplate}
                     fillColor={this.fillColor()}/>
             }
+            return (
+                <div className="double-graphic-container">
+                    { image }
+                </div>
+            );
         } else {
             return null
         }

--- a/src/js/Templates/Shared/Image.js
+++ b/src/js/Templates/Shared/Image.js
@@ -175,7 +175,7 @@ class Image extends React.Component {
             } else {
                 var style = {};
                 if (this.state.height && this.state.width) {
-                    if (this.state.height > this.state.width) {
+                    if (this.state.height >= this.state.width) {
                         style = {
                             height: "100%",
                             width: "auto"


### PR DESCRIPTION

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Show graphic in the LARGE_GRAPHIC_ONLY and LARGE_GRAPHIC_WITH_SOFTBUTTONS templates. Ensure sizing of image is contained within its parent div.

Core version / branch / commit hash / module tested against: 8.1
Proxy+Test App name / version / branch / commit hash / module tested against: rpcb-js

### Summary
Adds max and min height params to the containing divs of the large graphic class. 


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
