### PR TITLE
Set scrollbar-width to none

### DIFF
--- a/src/css/components/_h-scroll-menu.scss
+++ b/src/css/components/_h-scroll-menu.scss
@@ -3,6 +3,7 @@
     height: calc(#{$master-height} - 140px);
     overflow-y: auto;
     padding: calc(#{$master-height} / 21.6) 0px 0 0px;
+    scrollbar-width: none;
 
     @include display(flex);
     @include flex-direction(row);

--- a/src/css/components/_v-scroll-menu.scss
+++ b/src/css/components/_v-scroll-menu.scss
@@ -5,5 +5,6 @@
 }
 
 div::-webkit-scrollbar { 
-    display: none; 
+    display: none;
+    scrollbar-width: none;
 }


### PR DESCRIPTION

Fixes #513 
### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Perform interaction keyboard with ICON_WITH_SEARCH


### Summary
Sets the scroll bar width to none in order to fit 3 tiles in a row.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
