### PR TITLE
Set audio pass thru timer in OnRecordStart

### DIFF
--- a/src/js/Controllers/Controller.js
+++ b/src/js/Controllers/Controller.js
@@ -137,6 +137,7 @@ export default class Controller {
         this.subscribeToNotification("BasicCommunication.OnSystemCapabilityUpdated")
         this.subscribeToNotification("AppService.OnAppServiceData")
         this.subscribeToNotification("BasicCommunication.OnAppCapabilityUpdated")
+        this.subscribeToNotification("UI.OnRecordStart")
 
         var onSystemTimeReady = {
             "jsonrpc": "2.0",

--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -76,6 +76,7 @@ class UIController {
         this.timers = {}
         this.appsWithTimers = {}
         this.endTimes = {}
+        this.audioPassThruData = {}
     }
     addListener(listener) {
         this.listener = listener
@@ -338,14 +339,16 @@ class UIController {
                 const context = state.activeApp
 
                 this.endTimes[rpc.id] = Date.now() + rpc.params.maxDuration;
+                this.audioPassThruData[rpc.params.appID] = rpc;
                 this.timers[rpc.id] = setTimeout(
                     this.onClosePerformAudioPassThru, 
                     rpc.params.maxDuration,
                     rpc.id,
                     rpc.params.appID,
                     context,
-                    "TIMED_OUT"
+                    "SUCCESS"
                 );
+
                 this.appsWithTimers[rpc.id] = rpc.params.appID;
 
                 this.onSystemContext("HMI_OBSCURED", context)
@@ -365,6 +368,24 @@ class UIController {
                 );
                 return true;
             }
+            case "OnRecordStart":
+                var passThruRPC = this.audioPassThruData[rpc.params.appID];
+                if (passThruRPC) {
+                    const state = store.getState();
+                    const context = state.activeApp
+                    clearTimeout(this.timers[passThruRPC.id]);
+                    this.timers[passThruRPC.id] = setTimeout(
+                        this.onClosePerformAudioPassThru, 
+                        passThruRPC.params.maxDuration,
+                        passThruRPC.id,
+                        passThruRPC.params.appID,
+                        context,
+                        "SUCCESS"
+                    );
+                    this.endTimes[passThruRPC.id] = Date.now() + passThruRPC.params.maxDuration;
+                    this.appsWithTimers[passThruRPC.id] = passThruRPC.params.appID;
+                }
+                return null;
             case "Alert":
                 store.dispatch(alert(
                     rpc.params.appID,
@@ -426,7 +447,6 @@ class UIController {
                     rpc2.error.data.tryAgainTime = tryAgainTime;
                     return { rpc: rpc2 };
                 }
-
                 store.dispatch(alert(
                     rpc.params.appID,
                     rpc.params.alertStrings,
@@ -688,7 +708,8 @@ class UIController {
         if (this.timers[msgID]) {
             clearTimeout(this.timers[msgID])
         }
-        delete this.timers[msgID]
+        delete this.timers[msgID];
+        delete this.audioPassThruData[appID];
         store.dispatch(closePerformAudioPassThru(
             msgID,
             appID


### PR DESCRIPTION
Fixes #510 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
- Perform audio pass thru. Let popup close after timeout and retry test by clicking all of the perform audio pass thru pop up buttons.

Core version / branch / commit hash / module tested against: 8.1
Proxy+Test App name / version / branch / commit hash / module tested against: rpcb-js

### Summary
Adds a subscription to OnRecordStart. The timeout response is reset once that rpc is received.


### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
