### PR TITLE
Assume 30fps video from app when it cannot be auto-detected

### DIFF
--- a/tools/start_server.py
+++ b/tools/start_server.py
@@ -302,7 +302,7 @@ class RPCService(WSServer.SampleRPCService):
 
     else:
       server_endpoint = 'http://' + Flags.FILE_SERVER_HOST + ':' + str(Flags.VIDEO_SERVER_PORT)
-      ffmpeg_process = ffmpeg.input(_params['url']).output(server_endpoint, vcodec='vp8', format='webm', listen=1, multiple_requests=1).run_async(pipe_stderr=True)
+      ffmpeg_process = ffmpeg.input(_params['url'], framerate='30').output(server_endpoint, vcodec='vp8', format='webm', listen=1, multiple_requests=1).run_async(pipe_stderr=True)
       o = pexpect.fdpexpect.fdspawn(ffmpeg_process.stderr.fileno(), logfile=sys.stdout.buffer)
       index = o.expect(["Input", pexpect.EOF, pexpect.TIMEOUT])
 


### PR DESCRIPTION

Workaround for #520 

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Test video streaming with default framerate, verify `30 fps` is present in the backend logs:

```
Input #0, h264, from 'http://127.0.0.1:5050':
  Duration: N/A, bitrate: N/A
    Stream #0:0: Video: h264 (High), yuv420p(tv, smpte170m/bt470bg/smpte170m, progressive), 960x600, 30 fps, 30 tbr, 1200k tbn, 60 tbc
```

Core version / branch / commit hash / module tested against: develop
Proxy+Test App name / version / branch / commit hash / module tested against: Java Test Suite develop

### Summary
Assume 30fps video if ffmpeg cannot detect framerate of input video

### Changelog
##### Bug Fixes
* Assume 30fps video if ffmpeg cannot detect framerate of input video

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
