### PR TITLE
Only send WARNINGS response for missing alert images if normal result is SUCCESS

### DIFF
--- a/src/js/Controllers/UIController.js
+++ b/src/js/Controllers/UIController.js
@@ -761,15 +761,17 @@ class UIController {
             msgID,
             appID
         ))
-        const rpc = isSubtle
+        let rpc = isSubtle
             ? RpcFactory.SubtleAlertResponse(msgID)
             : RpcFactory.AlertResponse(msgID, appID);
 
         if (hadSoftbuttons) {
             rpc.result.code = 5; // ABORTED
+        } else if (!imageValidationSuccess) {
+            rpc = RpcFactory.InvalidImageResponse({ id: rpc.id, method: rpc.result.method })
         }
 
-        this.listener.send((imageValidationSuccess) ? rpc : RpcFactory.InvalidImageResponse({ id: rpc.id, method: rpc.result.method }))
+        this.listener.send(rpc)
 
         const systemContext = getNextSystemContext();
         if (appID !== context) {


### PR DESCRIPTION

Fixes https://github.com/smartdevicelink/generic_hmi/issues/523

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Core Tests
Perform steps described in issue

Core version / branch / commit hash / module tested against: release/8.2.0 branch

### Summary
Only send WARNINGS response for missing alert images if normal result is SUCCESS

### Changelog
##### Bug Fixes
* Only send WARNINGS response for missing alert images if normal result is SUCCESS

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
