### PR TITLE
Fix/Template SecondaryImage scaling

### DIFF
--- a/src/css/components/_non-media.scss
+++ b/src/css/components/_non-media.scss
@@ -164,6 +164,9 @@
         max-width: 100%;
         max-height: 100%;
     }
+    div {
+        padding: 0;
+    }
 }
 
 .soft-button-image-static {


### PR DESCRIPTION
Currently the secondary image is scaled differently depending on if isTemplate is enabled.

### Testing Plan
- [x] I have verified that I have not introduced new warnings in this PR (or explain why below)
- [x] I have tested this PR against Core and verified behavior (if applicable, if not applicable, explain why below).

#### Reproduction steps
1. Start Core and HMI
2. Register and activate app
3. Send a PutFile request with `{"syncFileName":"img1.png","fileType":"GRAPHIC_PNG"} `
4. Send AddCommand request with `{"cmdID":1,"menuParams":{"menuName":"Command 1"},"cmdIcon":{"value":"img1.png","imageType":"DYNAMIC","isTemplate":true},"secondaryImage":{"value":"img1.png","imageType":"DYNAMIC"}}`
5. Send AddCommand request with `{"cmdID":1,"menuParams":{"menuName":"Command 1"},"cmdIcon":{"value":"img1.png","imageType":"DYNAMIC","isTemplate":true},"secondaryImage":{"value":"img1.png","imageType":"DYNAMIC"}} `
6. Open app menu and compare the size of the secondaryImage for each command.

#### Core Tests

Core branch: release/8.2.0
Proxy+Test App name: rpc_builder

### Summary
Fix padding for `vscrollmenu-item__image`

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)
